### PR TITLE
Check _imageGallery Not Null And Bind Context To _handleIm…

### DIFF
--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -138,7 +138,9 @@ export default class ImageGallery extends React.Component {
   }
 
   _handleResize() {
-    this.setState({containerWidth: this._imageGallery.offsetWidth})
+    if (this._imageGallery !== null) {
+      this.setState({containerWidth: this._imageGallery.offsetWidth})
+    }
   }
 
   _getScrollX(indexDifference) {
@@ -274,7 +276,7 @@ export default class ImageGallery extends React.Component {
               src={item.original}
               alt={item.originalAlt}
               onLoad={this._handleImageLoad}
-              onError={this._handleImageError}/>
+              onError={this._handleImageError.bind(this)}/>
             {item.description}
         </div>
       )
@@ -306,7 +308,7 @@ export default class ImageGallery extends React.Component {
             <img
               src={item.thumbnail}
               alt={item.thumbnailAlt}
-              onError={this._handleImageError}/>
+              onError={this._handleImageError.bind(this)}/>
           </a>
         )
       }


### PR DESCRIPTION
…ageError

Side Note: These changes are untested, I would have pushed a build up to QA, but currently the build folder is in .gitignore and there is no prepublish command, so I can't test a remote fork without publishing to NPM (that I know of). It might be helpful to add a prepublish or a build script to fix that. 

## Fixes:


### _imageGallery is undefined on Mobile Safari sometimes 

![screen shot 2016-04-12 at 7 30 23 am](https://cloud.githubusercontent.com/assets/246603/14466381/7911afde-008b-11e6-977b-83a2844536d0.png)

![screen shot 2016-04-12 at 7 30 29 am](https://cloud.githubusercontent.com/assets/246603/14466386/7c57a310-008b-11e6-8c3c-7926dd9aa9f5.png)



### `this` is undefined on _handleImageError

![screen shot 2016-04-12 at 7 29 54 am](https://cloud.githubusercontent.com/assets/246603/14466423/a12941e4-008b-11e6-877b-477f68be9a08.png)

![screen shot 2016-04-12 at 7 30 10 am](https://cloud.githubusercontent.com/assets/246603/14466429/a81356a2-008b-11e6-9625-3e7bf2296b0d.png)






