### PR TITLE
Make SCSS variables overridable

### DIFF
--- a/src/image-gallery.scss
+++ b/src/image-gallery.scss
@@ -1,8 +1,8 @@
-$ig-screen-sm-min: 768px;
-$ig-white: #fff;
-$ig-black: #222;
-$ig-blue: #337ab7;
-$ig-background-black: rgba(0, 0, 0, .4);
+$ig-screen-sm-min: 768px !default;
+$ig-white: #fff !default;
+$ig-black: #222 !default;
+$ig-blue: #337ab7 !default;
+$ig-background-black: rgba(0, 0, 0, .4) !default;
 
 @mixin vendor-prefix($name, $value) {
   @each $vendor in ('-webkit-', '-moz-', '-ms-', '-o-', '') {


### PR DESCRIPTION
Just a little nicety that allows for the setting of `$ig-*` variables earlier in the code, so that this is possible:

_variables.scss
```scss
$custom-roses: red;
$custom-violets: blue;
...
// Image gallery
$ig-white: whitesmoke;
$ig-blue: darken($custom-violets, 5%);
```

_base.scss
```scss
@import 'variables';
@import '~react-image-gallery/src/image-gallery';
```

Thanks for your work! It's a huge help.