### PR TITLE
Fix Issue #54: Unexpected sliding direction in a 2-image gallery

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -387,7 +387,7 @@ export default class ImageGallery extends React.Component {
     let translateX = basetranslateX + (index * 100) + offsetPercentage
     let zIndex = 1
 
-    if (this.props.infinite && this.props.items.length > 1) {
+    if (this.props.infinite && this.props.items.length > 2) {
       if (currentIndex === 0 && index === totalSlides) {
         // make the last slide the slide before the first
         translateX = -100 + offsetPercentage


### PR DESCRIPTION
Fix for the issue where a 2-image gallery would cause the slider to go in the wrong direction.