### PR TITLE
Fix syntax error in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ class MyComponent extends React.Component {
         originalAlt: 'original-alt',
         thumbnailAlt: 'thumbnail-alt',
         thumbnailLabel: 'Optional',
-        description: 'Optional description...'
-        srcSet: 'Optional srcset (responsive images src)'
+        description: 'Optional description...',
+        srcSet: 'Optional srcset (responsive images src)',
         sizes: 'Optional sizes (image sizes relative to the breakpoint)'
       },
       {


### PR DESCRIPTION
Quick fix, just a few missing commas that were making the example code unrunnable.