### PR TITLE
Change R and L arrows, bullets to HTML buttons for accessibility.

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -688,7 +688,7 @@ export default class ImageGallery extends React.Component {
 
       if (this.props.showBullets) {
         bullets.push(
-          <li
+          <button
             key={index}
             className={
               'image-gallery-bullet ' + (
@@ -696,7 +696,7 @@ export default class ImageGallery extends React.Component {
 
             onTouchStart={event => this.slideToIndex.call(this, index, event)}
             onClick={event => this.slideToIndex.call(this, index, event)}>
-          </li>
+          </button>
         );
       }
     });
@@ -732,13 +732,13 @@ export default class ImageGallery extends React.Component {
                 [
                   this.props.showNav &&
                     <span key='navigation'>
-                      <a
+                      <button
                         className='image-gallery-left-nav'
                         disabled={!this._canSlideLeft()}
                         onTouchStart={slideLeft}
                         onClick={slideLeft}/>
 
-                      <a
+                      <button
                         className='image-gallery-right-nav'
                         disabled={!this._canSlideRight()}
                         onTouchStart={slideRight}

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -55,7 +55,7 @@ $ig-background-black: rgba(0, 0, 0, .4) !default;
   cursor: pointer;
   position: absolute;
   z-index: 4;
-
+  
   &::before {
     @extend %ion;
     color: $ig-white;
@@ -138,6 +138,11 @@ $ig-background-black: rgba(0, 0, 0, .4) !default;
   padding: 50px 15px;
   top: 50%;
   transform: translateY(-50%);
+  appearance: none;
+  background-color: transparent;
+  display: block;
+  padding: 0;
+  border: none;
 
   &[disabled] {
     cursor: disabled;
@@ -159,6 +164,7 @@ $ig-background-black: rgba(0, 0, 0, .4) !default;
 
   &::before {
     content: $ionicon-var-ios-arrow-left;
+    display: block;
   }
 }
 
@@ -167,6 +173,7 @@ $ig-background-black: rgba(0, 0, 0, .4) !default;
 
   &::before {
     content: $ionicon-var-ios-arrow-right;
+    display: block;
   }
 }
 
@@ -234,6 +241,8 @@ $ig-background-black: rgba(0, 0, 0, .4) !default;
     display: inline-block;
     margin: 0 5px;
     padding: 5px;
+    appearance: none;
+    background-color: transparent;
 
     @media (max-width: $ig-screen-sm-min) {
       margin: 0 3px;


### PR DESCRIPTION
Currently on master, the UI elements (R and L arrows, bullets) are not "focusable" because the `<a>` has no `href` attribute. If they are not "focusable", they are not accessible via a mouse-less interface, a requirement for ADA compliance. More information [here](http://webaim.org/techniques/keyboard/) and [here](https://www.nngroup.com/articles/keyboard-accessibility/)

This PR updates the the right and left arrows, bullets to use `<button>`s instead of `<a>`s and `<li>`s, respectively. The reason is three-fold: 

1. `<button>` is more semantically correct.
2. `<button>`s are "focusable".
3. While a `<button>` has focus, hitting enter acts like a click.

I'm not sure this is the best approach or best styling. I just wanted to flag it as a problem as well as offer a potential solution.