### PR TITLE
Add func prop to render custom controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ class MyComponent extends React.Component {
 * `onPause`: Function, `callback(currentIndex)`
 * `onPlay`: Function, `callback(currentIndex)`
 * `onClick`: Function, `callback(event)`
+* `renderCustomControls`: Function, custom controls rendering
+  * Use this to render custom controls or other elements on the currently displayed image (like the fullscreen button)
+  ```javascript
+    _renderCustomControls() {
+      return <a href='' className='image-gallery-custom-action' onClick={this._customAction.bind(this)}/>
+    }
+  ```
 * `renderItem`: Function, custom item rendering
   * As a prop on a specific item `[{thumbnail: '...', renderItem: '...'}]`
   * As a prop passed into `ImageGallery` to completely override `_renderItem`, see original below

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -701,6 +701,8 @@ export default class ImageGallery extends React.Component {
         <div className={`image-gallery-content${isFullscreen ? ' fullscreen' : ''}`}>
           <div className='image-gallery-slide-wrapper'>
 
+            {this.props.renderCustomControls && this.props.renderCustomControls()}
+
             {
               this.props.showFullscreenButton &&
                 <a
@@ -835,6 +837,7 @@ ImageGallery.propTypes = {
   onImageLoad: React.PropTypes.func,
   onImageError: React.PropTypes.func,
   onThumbnailError: React.PropTypes.func,
+  renderCustomControls: React.PropTypes.func,
   renderItem: React.PropTypes.func,
 };
 


### PR DESCRIPTION
Fixes #120 

This adds a new prop that will enable you to render custom controls/elements within the currently displayed image.

Should I add this to the example? Not exactly sure if that makes sense, the README should explain everything I think.