### PR TITLE
Render a placeholder div for omitted items

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -774,6 +774,11 @@ export default class ImageGallery extends React.Component {
       const renderItem = item.renderItem ||
         this.props.renderItem || this._renderItem.bind(this);
 
+      const showItem = !this.props.lazyLoad || alignment || this._lazyLoaded[index];
+      if (showItem && this.props.lazyLoad) {
+          this._lazyLoaded[index] = true;
+      }
+
       const slide = (
         <div
           key={index}
@@ -781,18 +786,11 @@ export default class ImageGallery extends React.Component {
           style={Object.assign(this._getSlideStyle(index), this.state.style)}
           onClick={this.props.onClick}
         >
-          {renderItem(item)}
+          {showItem ? renderItem(item) : <div style={{ height: '100%' }}></div>}
         </div>
       );
 
-      if (this.props.lazyLoad) {
-        if (alignment || this._lazyLoaded[index]) {
-          slides.push(slide);
-          this._lazyLoaded[index] = true;
-        }
-      } else {
-        slides.push(slide);
-      }
+      slides.push(slide);
 
       let onThumbnailError = this._handleImageError;
       if (this.props.onThumbnailError) {


### PR DESCRIPTION
With this change react-image-gallery renders a placeholder div in place of omitted items when lazy loading has been enabled. This seems to fix a case where clicking a yet unloaded image in thumbnail row causes the thumbnail row to briefly jump up since there is nothing in place of the soon-to-be-loaded image.

The jump can be seen in the example app when enabling lazy-loading and for example clicking a thumbnail several steps to the right of the first image. Also, example app in http://rig-lazyload.herokuapp.com/ exhibits the same behaviour.