### PR TITLE
Additional Accessibility Tweaks

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -93,6 +93,7 @@ export default class ImageGallery extends React.Component {
           className='image-gallery-left-nav'
           disabled={disabled}
           onClick={onClick}
+          aria-label='Previous Slide'
         />
       );
     },
@@ -103,6 +104,7 @@ export default class ImageGallery extends React.Component {
           className='image-gallery-right-nav'
           disabled={disabled}
           onClick={onClick}
+          aria-label='Next Slide'
         />
       );
     },
@@ -113,6 +115,7 @@ export default class ImageGallery extends React.Component {
           className={
             `image-gallery-play-button${isPlaying ? ' active' : ''}`}
           onClick={onClick}
+          aria-label='Play or Pause Slideshow'
         />
       );
     },
@@ -123,6 +126,7 @@ export default class ImageGallery extends React.Component {
           className={
             `image-gallery-fullscreen-button${isFullscreen ? ' active' : ''}`}
           onClick={onClick}
+          aria-label='Open Fullscreen'
         />
       );
     },
@@ -806,6 +810,9 @@ export default class ImageGallery extends React.Component {
             onMouseOver={this._handleMouseOverThumbnails.bind(this, index)}
             onMouseLeave={this._handleMouseLeaveThumbnails.bind(this, index)}
             key={index}
+            role='button'
+            aria-pressed={currentIndex === index ? 'true' : 'false'}
+            aria-label={`Go to Slide ${index + 1}`}
             className={
               'image-gallery-thumbnail' +
               (currentIndex === index ? ' active' : '') +
@@ -833,7 +840,10 @@ export default class ImageGallery extends React.Component {
               'image-gallery-bullet ' + (
                 currentIndex === index ? 'active' : '')}
 
-            onClick={event => this.slideToIndex.call(this, index, event)}>
+            onClick={event => this.slideToIndex.call(this, index, event)}
+            aria-pressed={currentIndex === index ? 'true' : 'false'}
+            aria-label={`Go to Slide ${index + 1}`}
+          >
           </button>
         );
       }
@@ -894,7 +904,11 @@ export default class ImageGallery extends React.Component {
         {
           this.props.showBullets &&
             <div className='image-gallery-bullets'>
-              <ul className='image-gallery-bullets-container'>
+              <ul 
+                className='image-gallery-bullets-container' 
+                role='navigation'
+                aria-label='Bullet Navigation'
+              >
                 {bullets}
               </ul>
             </div>
@@ -921,6 +935,7 @@ export default class ImageGallery extends React.Component {
         ref={i => this._imageGallery = i}
         className={
           `image-gallery${modalFullscreen ? ' fullscreen-modal' : ''}`}
+        aria-live='polite'
       >
 
         <div
@@ -944,8 +959,11 @@ export default class ImageGallery extends React.Component {
                   <div
                     ref={t => this._thumbnails = t}
                     className='image-gallery-thumbnails-container'
-                    style={thumbnailStyle}>
+                    style={thumbnailStyle}
+                    role='navigation'
+                    aria-label='Thumbnail Navigation'
                     {thumbnails}
+                  >
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Striving for compliance with WCAG 2.0, I added a few tweaks (attributes) to help screen readers and other assistive technologies. Attempting to make `react-image-gallery` fulfill Success Criteria 4.2.1 of WCAG 2.0:
https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html

- `aria-label` says what a particular button / UI element does
- `role` tells it to treat an element like a different element (`<a>` like a `<button>`, `<ul>` like a `<nav>`
- `aria-pressed` is for toggles
- `aria-live` is for content that updates "live"

More info: 
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
http://accessibility.athena-ict.com/aria/examples/carousel.shtml