### PR TITLE
Thumbnails Lazyload

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "watchify": "^3.8.0"
   },
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "lodash.throttle": "^4.1.1",
     "react-swipeable": "^3.5.1"
   }

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -152,7 +152,7 @@ export default class ImageGallery extends React.Component {
       // Keep progress for equal items.
       this.props.items.forEach((item, i) => {
         if (true !== this._isItemLazyLoadedSuccessfully[i] ||
-          !equal(item.original, nextProps.items[i].original)) {
+          item.original !== nextProps.items[i].original) {
           this._isItemLazyLoadedSuccessfully[i] = false;
         }
       });
@@ -396,9 +396,9 @@ export default class ImageGallery extends React.Component {
       }
 
       // adjust thumbnail container when thumbnail width or height is adjusted
-      this._setThumbsTranslate(
-        -this._getThumbsTranslate(
-          this.state.currentIndex > 0 ? 1 : 0) * this.state.currentIndex);
+      if (this.state.currentIndex > 0) {
+        this._setThumbsTranslate(-this._getThumbsTranslate(this.state.currentIndex));
+      }
 
       if (this._imageGallerySlideWrapper) {
         this.setState({


### PR DESCRIPTION
#88 

Thumbnails lazyload.
Main function: `_getThumbsVisibleRange()`
Every render cycle we load thumbnails for 2 screens (because a user can click on last visible thumbnail for the current state and I don't want to show a lot of default pictures in this case), before and after current item.
_If you do not have a desired number of images, we just load everything._

Prevent content jumping in lazyload mode.
Now we need to know which items loaded successfully. (If an item was not loaded we should set a size of the latest active element for the container of this item.)
For these purposes, I've added an array: `this._itemsLazyLoadedSuccessfully`
The array contains the URLs of all loaded images.
_All custom renderers should call the onImageLoad function or the image will be limited in height and width. (Only in lazyload mode)_

Please, let me know if you have any further questions.