### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install react-image-gallery
 @import "node_modules/react-image-gallery/styles/css/image-gallery.css";
 
 # Webpack
-import "react-image-gallery/styles/css/image-gallery";
+import "react-image-gallery/styles/css/image-gallery.css";
 
 # Stylesheet with no icons
 node_modules/react-image-gallery/styles/scss/image-gallery-no-icon.scss


### PR DESCRIPTION
Hey, thanks for a great component!

Not sure if this is a true typo or not since I'm not that familiar with Webpack and ES6 imports. But I couldn't get the CSS import to work without postfixing with `.css` so might be a good idea to update the README.