### PR TITLE
Slide to start when currentIndex outside of new images

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -150,6 +150,10 @@ export default class ImageGallery extends React.Component {
       (!this.props.lazyLoad || this.props.items !== nextProps.items)) {
       this._lazyLoaded = [];
     }
+
+    if (this.state.currentIndex >= nextProps.items.length) {
+      this.slideToIndex(0);
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
Run into small problem with gallery when trying to update component with smaller array of images - it shows nothing and counter looks like "4/3". 

This is a quick fix for emptiness in such case.