### PR TITLE
fix IE9

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -740,7 +740,7 @@ export default class ImageGallery extends React.Component {
       translate = `translate(0, ${this.state.thumbsTranslate}px)`;
     } else {
       translate3d = `translate3d(${this.state.thumbsTranslate}px, 0, 0)`;
-      translate = `translate3d(${this.state.thumbsTranslate}px, 0)`;
+      translate = `translate(${this.state.thumbsTranslate}px, 0)`;
     }
     return {
       WebkitTransform: translate3d,

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -720,11 +720,12 @@ export default class ImageGallery extends React.Component {
     }
 
     const translate3d = `translate3d(${translateX}%, 0, 0)`;
+    const translate = `translate(${translateX}%, 0)`;
 
     return {
       WebkitTransform: translate3d,
       MozTransform: translate3d,
-      msTransform: translate3d,
+      msTransform: translate,
       OTransform: translate3d,
       transform: translate3d,
       zIndex: zIndex
@@ -732,17 +733,19 @@ export default class ImageGallery extends React.Component {
   }
 
   _getThumbnailStyle() {
-    let translate3d;
+    let translate3d, translate;
 
     if (this._isThumbnailHorizontal()) {
       translate3d = `translate3d(0, ${this.state.thumbsTranslate}px, 0)`;
+      translate = `translate(0, ${this.state.thumbsTranslate}px)`;
     } else {
       translate3d = `translate3d(${this.state.thumbsTranslate}px, 0, 0)`;
+      translate = `translate3d(${this.state.thumbsTranslate}px, 0)`;
     }
     return {
       WebkitTransform: translate3d,
       MozTransform: translate3d,
-      msTransform: translate3d,
+      msTransform: translate,
       OTransform: translate3d,
       transform: translate3d
     };


### PR DESCRIPTION
Functions such as _getThumbnailStyle( ) and _getSlideStyle( ) pass translate3d property to msTransform, while msTransform supports only translate. It will cause the images not able to swipe in IE9