### PR TITLE
Fix vertical scrolling caused by preventDefault

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -935,6 +935,7 @@ export default class ImageGallery extends React.Component {
                     onSwipedRight={this._handleOnSwipedTo.bind(this, -1)}
                     onSwipedDown={this._handleOnSwipedTo.bind(this, 0)}
                     onSwipedUp={this._handleOnSwipedTo.bind(this, 0)}
+                    preventDefaultTouchmoveEvent={false}
                   >
                     <div className='image-gallery-slides'>
                       {slides}

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -933,8 +933,6 @@ export default class ImageGallery extends React.Component {
                     onSwiped={this._handleOnSwiped.bind(this)}
                     onSwipedLeft={this._handleOnSwipedTo.bind(this, 1)}
                     onSwipedRight={this._handleOnSwipedTo.bind(this, -1)}
-                    onSwipedDown={this._handleOnSwipedTo.bind(this, 0)}
-                    onSwipedUp={this._handleOnSwipedTo.bind(this, 0)}
                   >
                     <div className='image-gallery-slides'>
                       {slides}

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -933,6 +933,8 @@ export default class ImageGallery extends React.Component {
                     onSwiped={this._handleOnSwiped.bind(this)}
                     onSwipedLeft={this._handleOnSwipedTo.bind(this, 1)}
                     onSwipedRight={this._handleOnSwipedTo.bind(this, -1)}
+                    onSwipedDown={this._handleOnSwipedTo.bind(this, 0)}
+                    onSwipedUp={this._handleOnSwipedTo.bind(this, 0)}
                   >
                     <div className='image-gallery-slides'>
                       {slides}


### PR DESCRIPTION
Pass preventDefaultTouchmoveEvent=false to Swipeable. By default it was true, which was preventing the default vertical scrolling on mobile.

(this will happen with react-swipeable v4.0.0 anyway, see dogfessional/react-swipeable#69)