### PR TITLE
Remove handleResize on unmount

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -214,6 +214,7 @@ export default class ImageGallery extends React.Component {
 
     if (this._debounceResize) {
       window.removeEventListener('resize', this._debounceResize);
+      this._debounceResize.cancel();
     }
 
     this._offScreenChangeEvent();


### PR DESCRIPTION
When you unmount component during resize event, you can get warning:

"Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the ImageGallery component."

I just added debounce.cancel() in componentWillUnmoun