### PR TITLE
add stopPropagation optional prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ class MyComponent extends React.Component {
 * `swipeThreshold`: Integer, default `30`
   * A percentage of how far the offset of the current slide is swiped to trigger a slide event.
     e.g. If the current slide is swiped less than 30% to the left or right, it will not trigger a slide event.
+* `stopPropagation`: Boolean, default `false`
 * `startIndex`: Integer, default `0`
 * `onImageError`: Function, `callback(event)`
   * overrides defaultImage

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -72,7 +72,8 @@ export default class ImageGallery extends React.Component {
     renderRightNav: PropTypes.func,
     renderPlayPauseButton: PropTypes.func,
     renderFullscreenButton: PropTypes.func,
-    renderItem: PropTypes.func
+    renderItem: PropTypes.func,
+    stopPropagation: PropTypes.bool
   };
 
   static defaultProps = {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -993,6 +993,7 @@ export default class ImageGallery extends React.Component {
                     onSwipedRight={this._handleOnSwipedTo.bind(this, -1)}
                     onSwipedDown={this._handleOnSwipedTo.bind(this, 0)}
                     onSwipedUp={this._handleOnSwipedTo.bind(this, 0)}
+                    stopPropagation={this.props.stopPropagation}
                   >
                     <div className='image-gallery-slides'>
                       {slides}


### PR DESCRIPTION
It stops propagation of touch events of underlying Swipeable component, useful when there are nested swipeable views.