### PR TITLE
Use translate3d to get hw-acceleration on iOS

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -763,7 +763,7 @@ export default class ImageGallery extends React.Component {
       translateX = this._getTranslateXForTwoSlide(index);
     }
 
-    const translate = `translate(${translateX}%, 0)`;
+    const translate = `translate3d(${translateX}%, 0, 0)`;
 
     return {
       WebkitTransform: translate,
@@ -778,9 +778,9 @@ export default class ImageGallery extends React.Component {
     let translate;
 
     if (this._isThumbnailHorizontal()) {
-      translate = `translate(0, ${this.state.thumbsTranslate}px)`;
+      translate = `translate3d(0, ${this.state.thumbsTranslate}px, 0)`;
     } else {
-      translate = `translate(${this.state.thumbsTranslate}px, 0)`;
+      translate = `translate3d(${this.state.thumbsTranslate}px, 0, 0)`;
     }
     return {
       WebkitTransform: translate,


### PR DESCRIPTION
On iOS, hardware acceleration is only used for 3D translations. By using `translate3d(..)` instead of `translate(..)` you benefit from this. This results in a smoother and more performant experience.