### PR TITLE
expose preventDefaultTouchmoveEvent prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ class MyComponent extends React.Component {
 * `swipeThreshold`: Integer, default `30`
   * A percentage of how far the offset of the current slide is swiped to trigger a slide event.
     e.g. If the current slide is swiped less than 30% to the left or right, it will not trigger a slide event.
+* `stopPropagation`: Boolean, default `false`
 * `startIndex`: Integer, default `0`
 * `onImageError`: Function, `callback(event)`
   * overrides defaultImage

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ class MyComponent extends React.Component {
   * A percentage of how far the offset of the current slide is swiped to trigger a slide event.
     e.g. If the current slide is swiped less than 30% to the left or right, it will not trigger a slide event.
 * `stopPropagation`: Boolean, default `false`
+    * Automatically calls stopPropagation on all 'swipe' events.
 * `startIndex`: Integer, default `0`
 * `onImageError`: Function, `callback(event)`
   * overrides defaultImage

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -47,6 +47,7 @@ export default class ImageGallery extends React.Component {
     disableArrowKeys: PropTypes.bool,
     disableSwipe: PropTypes.bool,
     useBrowserFullscreen: PropTypes.bool,
+    preventDefaultTouchmoveEvent: PropTypes.bool,
     defaultImage: PropTypes.string,
     indexSeparator: PropTypes.string,
     thumbnailPosition: PropTypes.string,
@@ -92,6 +93,7 @@ export default class ImageGallery extends React.Component {
     disableArrowKeys: false,
     disableSwipe: false,
     useBrowserFullscreen: true,
+    preventDefaultTouchmoveEvent: false,
     indexSeparator: ' / ',
     thumbnailPosition: 'bottom',
     startIndex: 0,
@@ -995,6 +997,7 @@ export default class ImageGallery extends React.Component {
                     onSwipedDown={this._handleOnSwipedTo.bind(this, 0)}
                     onSwipedUp={this._handleOnSwipedTo.bind(this, 0)}
                     stopPropagation={this.props.stopPropagation}
+		    preventDefaultTouchmoveEvent={this.props.preventDefaultTouchmoveEvent}
                   >
                     <div className='image-gallery-slides'>
                       {slides}

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -72,7 +72,8 @@ export default class ImageGallery extends React.Component {
     renderRightNav: PropTypes.func,
     renderPlayPauseButton: PropTypes.func,
     renderFullscreenButton: PropTypes.func,
-    renderItem: PropTypes.func
+    renderItem: PropTypes.func,
+    stopPropagation: PropTypes.bool
   };
 
   static defaultProps = {
@@ -993,6 +994,7 @@ export default class ImageGallery extends React.Component {
                     onSwipedRight={this._handleOnSwipedTo.bind(this, -1)}
                     onSwipedDown={this._handleOnSwipedTo.bind(this, 0)}
                     onSwipedUp={this._handleOnSwipedTo.bind(this, 0)}
+                    stopPropagation={this.props.stopPropagation}
                   >
                     <div className='image-gallery-slides'>
                       {slides}


### PR DESCRIPTION
There is an issue on mobile when swiping, it tries to scroll up/down at the same time.

It would be godd to expose the `preventDefaultTouchmoveEvent` prop from `react-swipeable` so you have the option to prevent the browser's touchmove event if it is not desired. 