### PR TITLE
added a custom className prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ class MyComponent extends React.Component {
 * `onTouchStart`: Function, `callback(event) on gallery slide`
 * `onMouseOver`: Function, `callback(event) on gallery slide`
 * `onMouseLeave`: Function, `callback(event) on gallery slide`
+* `className`: String, 
+    * A custom className that will be added to the root node of this component.
 * `renderCustomControls`: Function, custom controls rendering
   * Use this to render custom controls or other elements on the currently displayed image (like the fullscreen button)
   ```javascript

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ class MyComponent extends React.Component {
 * `onTouchStart`: Function, `callback(event) on gallery slide`
 * `onMouseOver`: Function, `callback(event) on gallery slide`
 * `onMouseLeave`: Function, `callback(event) on gallery slide`
-* `className`: String, 
-    * A custom className that will be added to the root node of this component.
+* `additionalClass`: String, 
+    * An additional className that will be added to the root node of this component.
 * `renderCustomControls`: Function, custom controls rendering
   * Use this to render custom controls or other elements on the currently displayed image (like the fullscreen button)
   ```javascript

--- a/example/app.js
+++ b/example/app.js
@@ -195,6 +195,7 @@ class App extends React.Component {
           slideDuration={parseInt(this.state.slideDuration)}
           slideInterval={parseInt(this.state.slideInterval)}
           slideOnThumbnailHover={this.state.slideOnThumbnailHover}
+          className="app-image-gallery"
         />
 
         <div className='app-sandbox'>

--- a/example/app.js
+++ b/example/app.js
@@ -195,7 +195,7 @@ class App extends React.Component {
           slideDuration={parseInt(this.state.slideDuration)}
           slideInterval={parseInt(this.state.slideInterval)}
           slideOnThumbnailHover={this.state.slideOnThumbnailHover}
-          className="app-image-gallery"
+          additionalClass="app-image-gallery"
         />
 
         <div className='app-sandbox'>

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "watchify": "^3.8.0"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "watchify": "^3.8.0"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8",

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -3,7 +3,6 @@ import Swipeable from 'react-swipeable';
 import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 const screenChangeEvents = [
   'fullscreenchange',
@@ -79,7 +78,7 @@ export default class ImageGallery extends React.Component {
     renderFullscreenButton: PropTypes.func,
     renderItem: PropTypes.func,
     stopPropagation: PropTypes.bool,
-    className: PropTypes.string
+    additionalClass: PropTypes.string
   };
 
   static defaultProps = {
@@ -1116,10 +1115,16 @@ export default class ImageGallery extends React.Component {
       </div>
     );
 
+    const classNames = [
+      'image-gallery',
+      this.props.additionalClass,
+      modalFullscreen && 'fullscreen-modal'
+    ].filter(name => !!name).join(' ');
+
     return (
       <div
         ref={i => this._imageGallery = i}
-        className={classNames('image-gallery', this.props.className, { 'fullscreen-modal': modalFullscreen })}
+        className={classNames}
         aria-live='polite'
       >
 

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -3,6 +3,7 @@ import Swipeable from 'react-swipeable';
 import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 const screenChangeEvents = [
   'fullscreenchange',
@@ -77,7 +78,8 @@ export default class ImageGallery extends React.Component {
     renderPlayPauseButton: PropTypes.func,
     renderFullscreenButton: PropTypes.func,
     renderItem: PropTypes.func,
-    stopPropagation: PropTypes.bool
+    stopPropagation: PropTypes.bool,
+    className: PropTypes.string
   };
 
   static defaultProps = {
@@ -1117,8 +1119,7 @@ export default class ImageGallery extends React.Component {
     return (
       <div
         ref={i => this._imageGallery = i}
-        className={
-          `image-gallery${modalFullscreen ? ' fullscreen-modal' : ''}`}
+        className={classNames('image-gallery', this.props.className, { 'fullscreen-modal': modalFullscreen })}
         aria-live='polite'
       >
 


### PR DESCRIPTION
First off, thanks for making this great gallery component and taking the time to maintain it! 

This is only a small PR: 

**What:** A custom className prop. This will optionally add an extra className to the root node of the gallery. 

**Why:** Sometimes you need to target an element by className (css, check visibility...).  Targeting the default class of the component is not safe because what you can't control might change. Adding yet another div to wrap the component would be unnecessary if you could set a custom class. 