### PR TITLE
added 50ms to _onSliding

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -370,7 +370,7 @@ export default class ImageGallery extends React.Component {
       if (isTransitioning) {
         this.setState({isTransitioning: !isTransitioning});
       }
-    }, this.props.slideDuration);
+    }, this.props.slideDuration + 50);
   };
 
   getCurrentIndex() {


### PR DESCRIPTION
added 50ms to _onSliding. when infinite is set to true and the user holds down the arrow key, the transitioning slides don't behave as expected. the extra 50ms delays changing isTransitioning in state which fixes the transitioning problem