### PR TITLE
Add onModalClick prop

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -62,6 +62,7 @@ export default class ImageGallery extends React.Component {
     onPause: PropTypes.func,
     onPlay: PropTypes.func,
     onClick: PropTypes.func,
+    onModalClick: PropTypes.func,
     onImageLoad: PropTypes.func,
     onImageError: PropTypes.func,
     onTouchMove: PropTypes.func,
@@ -1119,6 +1120,7 @@ export default class ImageGallery extends React.Component {
         ref={i => this._imageGallery = i}
         className={
           `image-gallery${modalFullscreen ? ' fullscreen-modal' : ''}`}
+        onClick={this.props.onModalClick}
         aria-live='polite'
       >
 


### PR DESCRIPTION
I needed to use this component as a lightbox. In order to do that I needed a click handler on the fullscreen-modal div. Also the class `.fullscreen-modal` is only added if you disable the native browser fullscreen mode by setting the prop `useBrowserFullscreen={false}`

I would recommend checking for the fullscreen-modal class in the onModalClick event handler otherwise it will trigger for clicking anything in the imagegallery.

Example Use
---
```
onImageClick() {
  this.imageGallery.fullScreen()
}

onModalClick = ({ target }) => {
  if (target.classList.contains('fullscreen-modal')) {
    this.imageGallery.exitFullScreen()
  }
}
```

```
<ImageGallery
  ref={i => {
    this.imageGallery = i
  }}
  onClick={this.onImageClick}
  onModalClick={this.onModalClick}
  items={items}
  useBrowserFullscreen={false}
/>
```