### PR TITLE
Add role="button" with onClick prop to fix a11y violation

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -985,6 +985,7 @@ export default class ImageGallery extends React.Component {
           onTouchStart={this.props.onTouchStart}
           onMouseOver={this.props.onMouseOver}
           onMouseLeave={this.props.onMouseLeave}
+          role={this.props.onClick && 'button'}
         >
           {showItem ? renderItem(item) : <div style={{ height: '100%' }}></div>}
         </div>


### PR DESCRIPTION
This resolves a violation in the Firefox AInspector extension, used to test accessibility rules:

![screenshot 2017-12-15 11 42 04](https://user-images.githubusercontent.com/11855531/34051553-078a73ca-e18d-11e7-9641-b201d6ec2b07.png)
