### PR TITLE
Close #243: right to left languages support

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -20,6 +20,7 @@ class App extends React.Component {
       showPlayButton: true,
       showGalleryPlayButton: true,
       showNav: true,
+      isRTL: false,
       slideDuration: 450,
       slideInterval: 2000,
       thumbnailPosition: 'bottom',
@@ -205,6 +206,7 @@ class App extends React.Component {
           showThumbnails={this.state.showThumbnails}
           showIndex={this.state.showIndex}
           showNav={this.state.showNav}
+          isRTL={this.state.isRTL}
           thumbnailPosition={this.state.thumbnailPosition}
           slideDuration={parseInt(this.state.slideDuration)}
           slideInterval={parseInt(this.state.slideInterval)}
@@ -321,6 +323,14 @@ class App extends React.Component {
                   onChange={this._handleCheckboxChange.bind(this, 'slideOnThumbnailHover')}
                   checked={this.state.slideOnThumbnailHover}/>
                   <label htmlFor='slide_on_thumbnail_hover'>slide on thumbnail hover (desktop)</label>
+              </li>
+              <li>
+                <input
+                  id='is_rtl'
+                  type='checkbox'
+                  onChange={this._handleCheckboxChange.bind(this, 'isRTL')}
+                  checked={this.state.isRTL}/>
+                  <label htmlFor='is_rtl'>is right to left</label>
               </li>
             </ul>
           </div>

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -858,17 +858,19 @@ export default class ImageGallery extends React.Component {
 
   _getThumbnailStyle() {
     let translate;
-    const { useTranslate3D } = this.props;
+    const { useTranslate3D, isRTL } = this.props;
+    const { thumbsTranslate } = this.state;
+    const verticalTranslateValue = isRTL ? thumbsTranslate * -1 : thumbsTranslate;
 
     if (this._isThumbnailHorizontal()) {
-      translate = `translate(0, ${this.state.thumbsTranslate}px)`;
+      translate = `translate(0, ${thumbsTranslate}px)`;
       if (useTranslate3D) {
-        translate = `translate3d(0, ${this.state.thumbsTranslate}px, 0)`;
+        translate = `translate3d(0, ${thumbsTranslate}px, 0)`;
       }
     } else {
-      translate = `translate(${this.state.thumbsTranslate}px, 0)`;
+      translate = `translate(${verticalTranslateValue}px, 0)`;
       if (useTranslate3D) {
-        translate = `translate3d(${this.state.thumbsTranslate}px, 0, 0)`;
+        translate = `translate3d(${verticalTranslateValue}px, 0, 0)`;
       }
     }
     return {
@@ -965,6 +967,7 @@ export default class ImageGallery extends React.Component {
     const {
       infinite,
       preventDefaultTouchmoveEvent,
+      isRTL,
     } = this.props;
 
     const thumbnailStyle = this._getThumbnailStyle();
@@ -1097,8 +1100,8 @@ export default class ImageGallery extends React.Component {
             [
               this.props.showNav &&
                 <span key='navigation'>
-                  {this.props.renderLeftNav(slideLeft, !this._canSlideLeft())}
-                  {this.props.renderRightNav(slideRight, !this._canSlideRight())}
+                  {this.props.renderLeftNav(isRTL ? slideRight : slideLeft, !this._canSlideLeft())}
+                  {this.props.renderRightNav(isRTL ? slideLeft : slideRight, !this._canSlideRight())}
                 </span>,
 
                 this.props.disableSwipe ?
@@ -1162,6 +1165,7 @@ export default class ImageGallery extends React.Component {
     const classNames = [
       'image-gallery',
       this.props.additionalClass,
+      isRTL ? 'image-gallery-rtl' : '',
       modalFullscreen ? 'fullscreen-modal' : '',
     ].filter(name => typeof name === 'string').join(' ');
 

--- a/styles/scss/image-gallery-no-icon.scss
+++ b/styles/scss/image-gallery-no-icon.scss
@@ -16,6 +16,9 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
   @include vendor-prefix('user-select', none);
   -webkit-tap-highlight-color: $ig-transparent;
 
+  &.image-gallery-rtl {
+    direction: rtl;
+  }
   &.fullscreen-modal {
     background: $ig-black;
     bottom: 0;

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -18,6 +18,9 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
   @include vendor-prefix('user-select', none);
   -webkit-tap-highlight-color: $ig-transparent;
 
+  &.image-gallery-rtl {
+    direction: rtl;
+  }
   &.fullscreen-modal {
     background: $ig-black;
     bottom: 0;


### PR DESCRIPTION
Thank you for this library, after integrating it with our project we ran into a problem: the right to left support.

So, for this pull request:
1- I added `isRTL` prop to make the gallery direction from right to left.
2- I added `image-gallery-rtl ` class to add `direction: rtl` to the gallery.
3- When RTL is applied, the left button will be the next button, and the right will be the back button.
4- Multiplied the translate value with -1 to reverse the thumbnail transition.

Hope you will take a look soon.