### PR TITLE
Use disabled property of Swipeable to disable swipe

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -10,6 +10,7 @@ class App extends React.Component {
   constructor() {
     super();
     this.state = {
+      disableSwipe: false,
       showIndex: false,
       showBullets: true,
       infinite: true,
@@ -188,6 +189,7 @@ class App extends React.Component {
 
       <section className='app'>
         <ImageGallery
+          disableSwipe={this.state.disableSwipe}
           ref={i => this._imageGallery = i}
           items={this.images}
           lazyLoad={false}
@@ -311,6 +313,14 @@ class App extends React.Component {
                   onChange={this._handleCheckboxChange.bind(this, 'showIndex')}
                   checked={this.state.showIndex}/>
                   <label htmlFor='show_index'>show index</label>
+              </li>
+              <li>
+                <input
+                  id='disableSwipe'
+                  type='checkbox'
+                  onChange={this._handleCheckboxChange.bind(this, 'disableSwipe')}
+                  checked={this.state.disableSwipe}/>
+                  <label htmlFor='disableSwipe'>disable swipe (supported only on mobile device mode)</label>
               </li>
             </ul>
           </div>

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1073,29 +1073,25 @@ export default class ImageGallery extends React.Component {
                   {this.props.renderRightNav(slideRight, !this._canSlideRight())}
                 </span>,
 
-                this.props.disableSwipe ?
-                  <div className='image-gallery-slides' key='slides'>
+                <Swipeable
+                  className='image-gallery-swipe'
+                  disabled={this.props.disableSwipe}
+                  key='swipeable'
+                  delta={0}
+                  flickThreshold={this.props.flickThreshold}
+                  onSwiping={this._handleSwiping}
+                  onSwipingLeft={this._onSwipingNoOp}
+                  onSwipingRight={this._onSwipingNoOp}
+                  onSwipingUp={this._onSwipingNoOp}
+                  onSwipingDown={this._onSwipingNoOp}
+                  onSwiped={this._handleOnSwiped}
+                  stopPropagation={this.props.stopPropagation}
+                  preventDefaultTouchmoveEvent={preventDefaultTouchmoveEvent || scrollingLeftRight}
+                >
+                  <div className='image-gallery-slides'>
                     {slides}
                   </div>
-                :
-                  <Swipeable
-                    className='image-gallery-swipe'
-                    key='swipeable'
-                    delta={0}
-                    flickThreshold={this.props.flickThreshold}
-                    onSwiping={this._handleSwiping}
-                    onSwipingLeft={this._onSwipingNoOp}
-                    onSwipingRight={this._onSwipingNoOp}
-                    onSwipingUp={this._onSwipingNoOp}
-                    onSwipingDown={this._onSwipingNoOp}
-                    onSwiped={this._handleOnSwiped}
-                    stopPropagation={this.props.stopPropagation}
-                    preventDefaultTouchmoveEvent={preventDefaultTouchmoveEvent || scrollingLeftRight}
-                  >
-                    <div className='image-gallery-slides'>
-                      {slides}
-                    </div>
-                </Swipeable>
+              </Swipeable>
             ]
           :
             <div className='image-gallery-slides'>


### PR DESCRIPTION
**Problem:**
We would like to conditionally disable the swipe sometimes in order to support draggable feature like canvas dragging within the slide. But since this unmounts the `Swipeable` component and mounts a new `<div />` the local state is lost because the gallery re-renders completely with the new set of images.

**Possible Solution:**
Since [react-swipeavle](https://github.com/dogfessional/react-swipeable#props--config-options) supports `disabled` feature, we can use this to prevent the unmounting of the slides.