### PR TITLE
update react-swipeable, clean up no-op funcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8",
-    "react-swipeable": "^4.0.0"
+    "react-swipeable": "^4.2.2"
   }
 }

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -542,12 +542,6 @@ export default class ImageGallery extends React.Component {
     return Math.abs(this.state.offsetPercentage) > this.props.swipeThreshold;
   }
 
-  _onSwipingNoOp() {
-    /*
-    Do nothing, only defined so preventDefaultTouchmoveEvent works
-    */
-  }
-
   _handleSwiping = (e, deltaX, deltaY, delta) => {
     const { galleryWidth, isTransitioning, scrollingUpDown } = this.state;
     const { swipingTransitionDuration } = this.props;
@@ -1084,10 +1078,6 @@ export default class ImageGallery extends React.Component {
                     delta={0}
                     flickThreshold={this.props.flickThreshold}
                     onSwiping={this._handleSwiping}
-                    onSwipingLeft={this._onSwipingNoOp}
-                    onSwipingRight={this._onSwipingNoOp}
-                    onSwipingUp={this._onSwipingNoOp}
-                    onSwipingDown={this._onSwipingNoOp}
                     onSwiped={this._handleOnSwiped}
                     stopPropagation={this.props.stopPropagation}
                     preventDefaultTouchmoveEvent={preventDefaultTouchmoveEvent || scrollingLeftRight}


### PR DESCRIPTION
- update `react-swipeable` to `v4.2.2` to clean up no-op functions
  - https://github.com/dogfessional/react-swipeable/tree/v4.2.2

closes #268 