### PR TITLE
allow imageSet `source` attribute

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -872,6 +872,7 @@ export default class ImageGallery extends React.Component {
                     key={index}
                     media={source.media}
                     srcSet={source.srcSet}
+                    type={source.type}
                   />
                 ))
               }


### PR DESCRIPTION
This PR allows usage of the `type` attribute to be used in conjunction with the `imageSet` property. 

[`<source>` docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)