### PR TITLE
when use browser gallery use lightbox gallery

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="//fonts.googleapis.com/css?family=Raleway:300" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=Raleway:300" rel="stylesheet"/>
+    <link href="https://unpkg.com/react-image-lightbox@5.0.0/style.css" rel="stylesheet"/>
     <link rel="stylesheet" href="/css/image-gallery.css"/>
     <link rel="stylesheet" href="/app.css"/>
     <title>React Image Gallery</title>

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8",
+    "react-image-lightbox": "^5.0.0",
     "react-swipeable": "^4.2.2",
     "resize-observer-polyfill": "^1.5.0"
   }

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Swipeable from 'react-swipeable';
 import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
+import Lightbox from 'react-image-lightbox';
 import ResizeObserver from 'resize-observer-polyfill';
 import PropTypes from 'prop-types';
 
@@ -939,6 +940,7 @@ export default class ImageGallery extends React.Component {
     } = this.state;
 
     const {
+      items,
       infinite,
       preventDefaultTouchmoveEvent,
     } = this.props;
@@ -953,7 +955,7 @@ export default class ImageGallery extends React.Component {
     let thumbnails = [];
     let bullets = [];
 
-    this.props.items.forEach((item, index) => {
+    items.forEach((item, index) => {
       const alignment = this._getAlignmentClassName(index);
       const originalClass = item.originalClass ?
         ` ${item.originalClass}` : '';
@@ -1122,8 +1124,7 @@ export default class ImageGallery extends React.Component {
 
     const classNames = [
       'image-gallery',
-      this.props.additionalClass,
-      modalFullscreen ? 'fullscreen-modal' : '',
+      this.props.additionalClass
     ].filter(name => typeof name === 'string').join(' ');
 
     return (
@@ -1132,6 +1133,17 @@ export default class ImageGallery extends React.Component {
         className={classNames}
         aria-live='polite'
       >
+
+        {modalFullscreen && (
+          <Lightbox
+            mainSrc={items[currentIndex].original}
+            nextSrc={items[(currentIndex + 1) % items.length].original}
+            prevSrc={items[(currentIndex + items.length - 1) % items.length].original}
+            onCloseRequest={() => this.setModalFullscreen(false)} // eslint-disable-line
+            onMovePrevRequest={slideLeft}
+            onMoveNextRequest={slideRight}
+          />
+        )}
 
         <div
           className={`image-gallery-content${isFullscreen ? ' fullscreen' : ''}`}


### PR DESCRIPTION
When enable `useBrowserFullscreen` use beautiful image lightbox https://github.com/frontend-collective/react-image-lightbox, instead of very simple fullscreen mode.

Result:

![gallery](https://user-images.githubusercontent.com/1216029/43041529-f19199ee-8d95-11e8-8374-1befdbf83c27.gif)
