### PR TITLE
Remove logic for Slide to start when currentIndex outside of new images

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -173,10 +173,6 @@ export default class ImageGallery extends React.Component {
       (!this.props.lazyLoad || this.props.items !== nextProps.items)) {
       this._lazyLoaded = [];
     }
-
-    if (this.state.currentIndex >= nextProps.items.length) {
-      this.slideToIndex(0);
-    }
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
introduced by https://github.com/xiaolin/react-image-gallery/pull/170 because:

```
Run into small problem with gallery when trying to update component with smaller array of images - it shows nothing and counter looks like "4/3".

This is a quick fix for emptiness in such case.
```

The responsibility is of the caller (wrapper component) to set the correct index for the new set of images. You can do this by calling  `this._imageGallery.slideToIndex(someIndex)` from wrapper  `componentDidUpdate` lifecycle

The current logic results in weird UX where flickering images happen when `slideToIndex(0)` is called and then the wrapper component wants to explicitly set a new index for the new image set. 