### PR TITLE
control buttons appear on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ class MyComponent extends React.Component {
   * infinite sliding
 * `lazyLoad`: Boolean, default `false`
 * `showNav`: Boolean, default `true`
+* `autohideControls`: Boolean, default `false`
+  * All control buttons appear only when mouse is over the component
 * `showThumbnails`: Boolean, default `true`
 * `thumbnailPosition`: String, default `bottom`
   * available positions: `top, right, bottom, left`

--- a/example/app.js
+++ b/example/app.js
@@ -24,6 +24,7 @@ class App extends React.Component {
       slideInterval: 2000,
       thumbnailPosition: 'bottom',
       showVideo: {},
+      autohideControls: false,
     };
 
     this.images = [
@@ -210,6 +211,7 @@ class App extends React.Component {
           slideDuration={parseInt(this.state.slideDuration)}
           slideInterval={parseInt(this.state.slideInterval)}
           additionalClass="app-image-gallery"
+          autohideControls={this.state.autohideControls}
         />
 
         <div className='app-sandbox'>
@@ -321,6 +323,14 @@ class App extends React.Component {
                   onChange={this._handleCheckboxChange.bind(this, 'isRTL')}
                   checked={this.state.isRTL}/>
                   <label htmlFor='is_rtl'>is right to left</label>
+              </li>
+              <li>
+                <input
+                  id='autohide_controls'
+                  type='checkbox'
+                  onChange={this._handleCheckboxChange.bind(this, 'autohideControls')}
+                  checked={this.state.autohideControls}/>
+                  <label htmlFor='autohide_controls'>autohide control buttons</label>
               </li>
             </ul>
           </div>

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -88,7 +88,8 @@ export default class ImageGallery extends React.Component {
     stopPropagation: PropTypes.bool,
     additionalClass: PropTypes.string,
     useTranslate3D: PropTypes.bool,
-    isRTL: PropTypes.bool
+    isRTL: PropTypes.bool,
+    autohideControls: PropTypes.bool
   };
 
   static defaultProps = {
@@ -118,6 +119,7 @@ export default class ImageGallery extends React.Component {
     swipingTransitionDuration: 0,
     slideInterval: 3000,
     swipeThreshold: 30,
+    autohideControls: false,
     renderLeftNav: (onClick, disabled) => {
       return (
         <button
@@ -964,6 +966,7 @@ export default class ImageGallery extends React.Component {
       infinite,
       preventDefaultTouchmoveEvent,
       isRTL,
+      autohideControls,
     } = this.props;
 
     const thumbnailStyle = this._getThumbnailStyle();
@@ -1069,7 +1072,7 @@ export default class ImageGallery extends React.Component {
     const slideWrapper = (
       <div
         ref={this._initGalleryResizing}
-        className={`image-gallery-slide-wrapper ${thumbnailPosition} ${isRTL ? 'image-gallery-rtl' : ''}`}
+        className={`image-gallery-slide-wrapper ${thumbnailPosition} ${isRTL ? 'image-gallery-rtl' : ''} ${autohideControls ? 'autohide-controls' : ''}`}
       >
 
         {this.props.renderCustomControls && this.props.renderCustomControls()}

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -54,6 +54,15 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
 .image-gallery-slide-wrapper {
   position: relative;
 
+  button {
+    opacity: 0.0;
+    transition: opacity 450ms;
+  }
+
+  &:hover button {
+    opacity: 1.0;
+  }
+
   &.left,
   &.right {
     display: inline-block;

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -54,13 +54,15 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
 .image-gallery-slide-wrapper {
   position: relative;
 
-  button {
-    opacity: 0.0;
-    transition: opacity 450ms;
-  }
+  &.autohide-controls {
+    button {
+      opacity: 0.0;
+      transition: opacity 450ms;
+    }
 
-  &:hover button {
-    opacity: 1.0;
+    &:hover button {
+      opacity: 1.0;
+    }
   }
 
   &.left,


### PR DESCRIPTION
new property:
`autohideControls`: Boolean, default `false`
Control buttons (prev/next, autoplay, fullscreen, bullets, etc...) appear only when mouse is over the gallery area.