### PR TITLE
Add `style` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "https://github.com/xiaolin/react-image-gallery.git"
   },
+  "style": "styles/css/image-gallery.css",
   "keywords": [
     "react",
     "carousel",


### PR DESCRIPTION
This change enables `postcss-import` and other tools to infer which CSS file is the correct one to import when referencing the module name. This means users can do `@import 'react-image-gallery';` and it will import the correct stylesheet. This change should make it a _little_ bit easier for people to get started using `react-image-gallery`.

More on the `style` attribute: https://jaketrent.com/post/package-json-style-attribute/