### PR TITLE
please bring  context to renderItem function

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1026,7 +1026,7 @@ export default class ImageGallery extends React.Component {
           onMouseLeave={this.props.onMouseLeave}
           role={this.props.onClick && 'button'}
         >
-          {showItem ? renderItem(item) : <div style={{ height: '100%' }}></div>}
+          {showItem ? renderItem(item, this) : <div style={{ height: '100%' }}></div>}
         </div>
       );
 


### PR DESCRIPTION
i'm building a custom render item function that needs to call fullscreen() when an user clicks the image, i thought having the context would be helpful.