### PR TITLE
feat: multiple galleries on same page support with improved (exit)fullscreen change handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ npm-debug.log
 .DS_Store
 
 .idea
+.vscode
 
 build/
 example/example.js

--- a/README.md
+++ b/README.md
@@ -136,7 +136,12 @@ class MyGallery extends React.Component {
 * `onThumbnailClick`: Function, `callback(event, index)`
 * `onImageLoad`: Function, `callback(event)`
 * `onSlide`: Function, `callback(currentIndex)`
-* `onScreenChange`: Function, `callback(fullscreenElement)`
+* `onScreenChange`: Function, `callback(fullscreenElement, wasInFullscreen)`
+  * `fullscreenElement` will either be a DOM node or a boolean (for unsupported
+    browsers)
+  * the gallery's previous fullscreen state. This helps selecting the active
+    gallery when multiple galleries are present on the same page, because all
+    of them will invoke `onScreenChange` when one changes to fullscreen mode.
 * `onPause`: Function, `callback(currentIndex)`
 * `onPlay`: Function, `callback(currentIndex)`
 * `onClick`: Function, `callback(event)`

--- a/example/app.js
+++ b/example/app.js
@@ -336,6 +336,43 @@ class App extends React.Component {
           </div>
 
         </div>
+
+        <div className="app-sandbox">
+          <div className="app-sandbox-content">
+            <h2 className="app-header">Multiple Galleries on the same Page</h2>
+            <p>
+              react-image-gallery supports rendering multiple instances of
+              ImageGallery on the same page. Only one gallery will be in
+              fullscreen mode when one changes its state. Arrow Keys will only
+              work when the gallery is hovered on desktop or when the user
+              swipes on mobile devices.
+            </p>
+          </div>
+        </div>
+
+        <ImageGallery
+          items={this.images}
+          lazyLoad={false}
+          onClick={this._onImageClick.bind(this)}
+          onImageLoad={this._onImageLoad}
+          onSlide={this._onSlide.bind(this)}
+          onPause={this._onPause.bind(this)}
+          onScreenChange={this._onScreenChange.bind(this)}
+          onPlay={this._onPlay.bind(this)}
+          infinite={this.state.infinite}
+          showBullets={this.state.showBullets}
+          showFullscreenButton={this.state.showFullscreenButton && this.state.showGalleryFullscreenButton}
+          showPlayButton={this.state.showPlayButton && this.state.showGalleryPlayButton}
+          showThumbnails={this.state.showThumbnails}
+          showIndex={this.state.showIndex}
+          showNav={this.state.showNav}
+          isRTL={this.state.isRTL}
+          thumbnailPosition={this.state.thumbnailPosition}
+          slideDuration={parseInt(this.state.slideDuration)}
+          slideInterval={parseInt(this.state.slideInterval)}
+          slideOnThumbnailOver={this.state.slideOnThumbnailOver}
+          additionalClass="app-image-gallery"
+        />
       </section>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-gallery",
-  "version": "0.9.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -196,6 +196,15 @@ export default class ImageGallery extends React.Component {
     ),
   };
 
+  static getFullScreenElement() {
+    return (
+      document.fullscreenElement
+      || document.msFullscreenElement
+      || document.mozFullScreenElement
+      || document.webkitFullscreenElement
+    );
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -207,6 +216,7 @@ export default class ImageGallery extends React.Component {
       thumbnailsWrapperHeight: 0,
       isFullscreen: false,
       isPlaying: false,
+      isInFocus: false,
     };
     this.loadedImages = {};
     this.imageGallery = React.createRef();
@@ -220,6 +230,8 @@ export default class ImageGallery extends React.Component {
     this.handleOnSwiped = this.handleOnSwiped.bind(this);
     this.handleScreenChange = this.handleScreenChange.bind(this);
     this.handleSwiping = this.handleSwiping.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.onBlur = this.onBlur.bind(this);
     this.onThumbnailMouseLeave = this.onThumbnailMouseLeave.bind(this);
     this.pauseOrPlay = this.pauseOrPlay.bind(this);
     this.renderThumbInner = this.renderThumbInner.bind(this);
@@ -308,6 +320,18 @@ export default class ImageGallery extends React.Component {
     }
   }
 
+  onFocus() {
+    this.setState({
+      isInFocus: true,
+    });
+  }
+
+  onBlur() {
+    this.setState({
+      isInFocus: false,
+    });
+  }
+
   onSliding() {
     const { currentIndex, isTransitioning } = this.state;
     const { onSlide, slideDuration } = this.props;
@@ -369,11 +393,26 @@ export default class ImageGallery extends React.Component {
 
   setModalFullscreen(state) {
     const { onScreenChange } = this.props;
-    this.setState({ modalFullscreen: state });
-    // manually call because browser does not support screenchange events
-    if (onScreenChange) {
-      onScreenChange(state);
-    }
+    const { isFullscreen: prevIsFullscreen } = this.state;
+
+    // update both isFullscreen _and_ modalFullscreen
+    this.setState(
+      {
+        isFullscreen: state,
+        modalFullscreen: state,
+      },
+      () => {
+        // manually call because browser does not support screenchange events
+        if (onScreenChange) {
+          onScreenChange(
+            state
+              ? this.imageGallery.current
+              : null,
+            prevIsFullscreen,
+          );
+        }
+      },
+    );
   }
 
   getThumbsTranslate(indexDifference) {
@@ -882,7 +921,8 @@ export default class ImageGallery extends React.Component {
 
   handleKeyDown(event) {
     const { disableKeyDown, useBrowserFullscreen } = this.props;
-    const { isFullscreen } = this.state;
+    // only allow left and right arrow keys, when the current gallery is hovered
+    const { isFullscreen, isInFocus } = this.state;
     // keep track of mouse vs keyboard usage for a11y
     this.imageGallery.current.classList.remove('image-gallery-using-mouse');
 
@@ -894,12 +934,12 @@ export default class ImageGallery extends React.Component {
 
     switch (key) {
       case LEFT_ARROW:
-        if (this.canSlideLeft() && !this.intervalId) {
+        if (this.canSlideLeft() && !this.intervalId && isInFocus) {
           this.slideLeft();
         }
         break;
       case RIGHT_ARROW:
-        if (this.canSlideRight() && !this.intervalId) {
+        if (this.canSlideRight() && !this.intervalId && isInFocus) {
           this.slideRight();
         }
         break;
@@ -982,17 +1022,36 @@ export default class ImageGallery extends React.Component {
 
 
   handleScreenChange() {
-    /*
-      handles screen change events that the browser triggers e.g. esc key
-    */
+    /**
+     * handles screen change events that the browser triggers (e.g. esc key),
+     * but only if the current instance is the gallery shown in fullscreen mode.
+     * This is especially useful, when multiple galleries are used on a single
+     * page.
+     */
     const { onScreenChange } = this.props;
-    const fullScreenElement = document.fullscreenElement
-      || document.msFullscreenElement
-      || document.mozFullScreenElement
-      || document.webkitFullscreenElement;
+    const { isFullscreen: prevIsFullscreen } = this.state;
 
-    if (onScreenChange) onScreenChange(fullScreenElement);
-    this.setState({ isFullscreen: !!fullScreenElement });
+    const fullScreenElement = ImageGallery.getFullScreenElement();
+    // only for _one_ gallery on the page this will evaluate to true
+    const isFullscreen = this.imageGallery.current === fullScreenElement;
+
+    this.setState(
+      {
+        isFullscreen,
+      },
+      () => {
+        if (onScreenChange) {
+          /**
+           * in order to detect the current gallery going changing to
+           * fullscreen, `onScreenChange will provide a second argument.
+           */
+          onScreenChange(
+            isFullscreen ? fullScreenElement : null,
+            prevIsFullscreen,
+          );
+        }
+      },
+    );
   }
 
   slideToIndex(index, event) {
@@ -1092,6 +1151,14 @@ export default class ImageGallery extends React.Component {
   fullScreen() {
     const { useBrowserFullscreen } = this.props;
     const gallery = this.imageGallery.current;
+
+    /**
+     * ATTENTION: do not handle this.state.isFullscreen here (and in
+     * exitFullScreen), instead `handleScreenChange` and `setModalFullscreen`
+     * should handle it. This is especially useful, when multiple galleries are
+     * on the same page. Only the gallery in fullscreen-mode will change it's
+     * state properly.
+     */
     if (useBrowserFullscreen) {
       if (gallery.requestFullscreen) {
         gallery.requestFullscreen();
@@ -1108,7 +1175,6 @@ export default class ImageGallery extends React.Component {
     } else {
       this.setModalFullscreen(true);
     }
-    this.setState({ isFullscreen: true });
   }
 
   exitFullScreen() {
@@ -1131,7 +1197,6 @@ export default class ImageGallery extends React.Component {
       } else {
         this.setModalFullscreen(false);
       }
-      this.setState({ isFullscreen: false });
     }
   }
 
@@ -1380,6 +1445,10 @@ export default class ImageGallery extends React.Component {
         ref={this.imageGallery}
         className={igClass}
         aria-live="polite"
+        onMouseOver={this.onFocus}
+        onFocus={this.onFocus}
+        onMouseOut={this.onBlur}
+        onBlur={this.onBlur}
       >
         <div className={igContentClass}>
           {(thumbnailPosition === 'bottom' || thumbnailPosition === 'right') && slideWrapper}

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -934,12 +934,12 @@ export default class ImageGallery extends React.Component {
 
     switch (key) {
       case LEFT_ARROW:
-        if (this.canSlideLeft() && !this.intervalId && isInFocus) {
+        if (!this.intervalId && isInFocus && this.canSlideLeft()) {
           this.slideLeft();
         }
         break;
       case RIGHT_ARROW:
-        if (this.canSlideRight() && !this.intervalId && isInFocus) {
+        if (!this.intervalId && isInFocus && this.canSlideRight()) {
           this.slideRight();
         }
         break;
@@ -1042,8 +1042,8 @@ export default class ImageGallery extends React.Component {
       () => {
         if (onScreenChange) {
           /**
-           * in order to detect the current gallery going changing to
-           * fullscreen, `onScreenChange will provide a second argument.
+           * in order to detect the current gallery going to change to
+           * fullscreen, `onScreenChange` will provide a second argument.
            */
           onScreenChange(
             isFullscreen ? fullScreenElement : null,


### PR DESCRIPTION
## Previous Behaviour

Previously, when one rendered multiple galleries on the same page _all_ reacted when pressing the arrow keys _and all_ galleries thought they were in fullscreen mode when one changed to fullscreen.

## Future Behaviour

Now, only _one_ gallery will react to arrow keys when the gallery **is hovered on desktop or swiped on mobile devices**. Additionally, **only the actual fullscreen-gallery will change it's `isFullscreen` state to true**. All others stay the same.

Both changes need to be kept together to enable full multiple-gallery support.

## How to test

Start the demo app and interact with one of the two galleries. Debug the state with the [react extension for chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=de) and try the arrow keys by simply hovering and pressing the left- or right-arrow key.

## Related (resolved) Issues

- https://github.com/xiaolin/react-image-gallery/issues/451
- smaller (focused) version of https://github.com/xiaolin/react-image-gallery/pull/446

## Arrow Keys work properly for multiple galleries on the same page

proof (gif): https://d.pr/i/R6OxJL/RoOWebWJDh

## Only one gallery's `isFullscreen` state changes in fullscreen mode

proof (gif): https://d.pr/i/AIlQMM/Fo5CIfub6o

## Other Notes

- `example/app.js` does not comply with the provided ESLint rules
- `.eslintrc.json` is the only file with different spaces rule (4 vs the default 2 in other files)
- I recommend adding [prettier](https://prettier.io/) to the project to enable worry-free auto-formatting with eg. [VS Code](https://code.visualstudio.com/), but also works IDE independent (with eg. [husky](https://www.npmjs.com/package/husky) and [lint-staged](https://github.com/okonet/lint-staged)). Note: I do not know your editor settings, but I had to disable some in VS Code to disable formatting but still the editor applied some formatting after saving the file... ==> Example: https://d.pr/i/JAS2Fs/ene8fioHXr

Would be awesome if you could think about adding prettier or set up some editorconfig. thx!
 