### PR TITLE
Add onBeforeSlide callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ class MyGallery extends React.Component {
 * `onThumbnailClick`: Function, `callback(event, index)`
 * `onImageLoad`: Function, `callback(event)`
 * `onSlide`: Function, `callback(currentIndex)`
+* `onBeforeSlide`: Function, `callback(currentIndex)`
 * `onScreenChange`: Function, `callback(fullscreenElement)`
 * `onPause`: Function, `callback(currentIndex)`
 * `onPlay`: Function, `callback(currentIndex)`

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ class MyGallery extends React.Component {
 * `onThumbnailClick`: Function, `callback(event, index)`
 * `onImageLoad`: Function, `callback(event)`
 * `onSlide`: Function, `callback(currentIndex)`
-* `onBeforeSlide`: Function, `callback(currentIndex)`
+* `onBeforeSlide`: Function, `callback(nextIndex)`
 * `onScreenChange`: Function, `callback(fullscreenElement)`
 * `onPause`: Function, `callback(currentIndex)`
 * `onPlay`: Function, `callback(currentIndex)`

--- a/example/app.js
+++ b/example/app.js
@@ -81,6 +81,10 @@ class App extends React.Component {
     console.debug('slid to index', index);
   }
 
+  _onBeforeSlide(index) {
+    console.debug('sliding to index', index);
+  }
+
   _onPause(index) {
     console.debug('paused on index', index);
   }
@@ -196,6 +200,7 @@ class App extends React.Component {
           onClick={this._onImageClick.bind(this)}
           onImageLoad={this._onImageLoad}
           onSlide={this._onSlide.bind(this)}
+          onBeforeSlide={this._onBeforeSlide.bind(this)}
           onPause={this._onPause.bind(this)}
           onScreenChange={this._onScreenChange.bind(this)}
           onPlay={this._onPlay.bind(this)}

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1018,7 +1018,7 @@ export default class ImageGallery extends React.Component {
         nextIndex = 0;
       }
 
-      if (onBeforeSlide) {
+      if (onBeforeSlide && nextIndex !== currentIndex) {
         onBeforeSlide(nextIndex);
       }
 

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -80,6 +80,7 @@ export default class ImageGallery extends React.Component {
     swipeThreshold: number,
     swipingTransitionDuration: number,
     onSlide: func,
+    onBeforeSlide: func,
     onScreenChange: func,
     onPause: func,
     onPlay: func,
@@ -133,6 +134,7 @@ export default class ImageGallery extends React.Component {
     slideDuration: 450,
     swipingTransitionDuration: 0,
     onSlide: null,
+    onBeforeSlide: null,
     onScreenChange: null,
     onPause: null,
     onPlay: null,
@@ -258,6 +260,7 @@ export default class ImageGallery extends React.Component {
       slideDuration,
       startIndex,
       thumbnailPosition,
+      onBeforeSlide,
     } = this.props;
     const { currentIndex } = this.state;
     const itemsSizeChanged = prevProps.items.length !== items.length;
@@ -275,6 +278,10 @@ export default class ImageGallery extends React.Component {
       this.handleResize();
     }
     if (prevState.currentIndex !== currentIndex) {
+      if (onBeforeSlide) {
+        onBeforeSlide(currentIndex);
+      }
+
       this.slideThumbnailBar(prevState.currentIndex);
     }
     // if slideDuration changes, update slideToIndex throttle

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -260,7 +260,6 @@ export default class ImageGallery extends React.Component {
       slideDuration,
       startIndex,
       thumbnailPosition,
-      onBeforeSlide,
     } = this.props;
     const { currentIndex } = this.state;
     const itemsSizeChanged = prevProps.items.length !== items.length;
@@ -278,10 +277,6 @@ export default class ImageGallery extends React.Component {
       this.handleResize();
     }
     if (prevState.currentIndex !== currentIndex) {
-      if (onBeforeSlide) {
-        onBeforeSlide(currentIndex);
-      }
-
       this.slideThumbnailBar(prevState.currentIndex);
     }
     // if slideDuration changes, update slideToIndex throttle
@@ -1004,7 +999,7 @@ export default class ImageGallery extends React.Component {
 
   slideToIndex(index, event) {
     const { currentIndex, isTransitioning } = this.state;
-    const { items, slideDuration } = this.props;
+    const { items, slideDuration, onBeforeSlide } = this.props;
 
     if (!isTransitioning) {
       if (event) {
@@ -1021,6 +1016,10 @@ export default class ImageGallery extends React.Component {
         nextIndex = slideCount;
       } else if (index > slideCount) {
         nextIndex = 0;
+      }
+
+      if (onBeforeSlide) {
+        onBeforeSlide(nextIndex);
       }
 
       this.setState({


### PR DESCRIPTION
If accepted, will resolve #466. This restores the previous (`<= v0.8.12`) functionality of the `onSlide` callback by naming it `onBeforeSlide`, as it is called just before the slide transition occurs.