### PR TITLE
Fix on screen change

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1002,14 +1002,14 @@ export default class ImageGallery extends React.Component {
     /*
       handles screen change events that the browser triggers e.g. esc key
     */
-    const { onScreenChange } = this.props;
+    const { onScreenChange, useBrowserFullscreen } = this.props;
     const fullScreenElement = document.fullscreenElement
       || document.msFullscreenElement
       || document.mozFullScreenElement
       || document.webkitFullscreenElement;
 
     if (onScreenChange) onScreenChange(fullScreenElement);
-    this.setState({ isFullscreen: !!fullScreenElement });
+    if (useBrowserFullscreen) this.setState({ isFullscreen: !!fullScreenElement });
   }
 
   slideToIndex(index, event) {


### PR DESCRIPTION
Original issue:
1. set useBrowswerFullScreen to false
2. Add an iframe to you slides
3. Toggle slider full screen
4. Toggle full screen in iframe (like youtube full screen)
5. Press escape or collapse youtube full screen

Actual: slider will stuck in full screen mode
This happens because onScreenChange handler assumes that you closed full screen, however this not true in case if you use css full screen
