### PR TITLE
Allow function value for disableKeyDown to support dynamic determination of keydown handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ class MyGallery extends React.Component {
 * `autoPlay`: Boolean, default `false`
 * `disableThumbnailScroll`: Boolean, default `false`
   * disables the thumbnail container from adjusting
-* `disableKeyDown`: Boolean, default `false`
+* `disableKeyDown`: Boolean or Function, default `false`
   * disables keydown listener for keyboard shortcuts (left arrow, right arrow, esc key)
+  * if a function is provided, it is called with the KeyDown event. If the function returns true, the event does not change the image.
 * `disableSwipe`: Boolean, default `false`
 * `onErrorImageURL`: String, default `undefined`
   * an image src pointing to your default image if an image fails to load

--- a/example/app.js
+++ b/example/app.js
@@ -25,6 +25,7 @@ class App extends React.Component {
       slideOnThumbnailOver: false,
       thumbnailPosition: 'bottom',
       showVideo: {},
+      disableKeyDown: false,
     };
 
     this.images = [
@@ -57,6 +58,8 @@ class App extends React.Component {
         description: 'Custom class for slides & thumbnails'
       },
     ].concat(this._getStaticImages());
+
+    this.wrapperRef = React.createRef();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -103,6 +106,33 @@ class App extends React.Component {
 
   _handleThumbnailPositionChange(event) {
     this.setState({thumbnailPosition: event.target.value});
+  }
+
+  _handleDisableKeyDownControl(event) {
+    const that = this;
+    const disableKeyDownChoice = event.target.value;
+    this.setState({ disableKeyDownChoice });
+    switch(disableKeyDownChoice) {
+      case 'true':
+        this.setState({disableKeyDown: true});
+        break;
+      case 'false':
+        this.setState({disableKeyDown: false});
+        break;
+      case 'focusOutsideGallery':
+        this.setState({disableKeyDown: event => {
+          return !that.wrapperRef.current.contains(event.target);
+        }});
+        break;
+      case 'focusInInputs':
+        this.setState({disableKeyDown: event => {
+          return ['INPUT', 'SELECT', 'TEXTAREA'].includes(
+            event.target.tagName
+          );
+        }});
+      default:
+        break;
+    }
   }
 
   _getStaticImages() {
@@ -189,30 +219,33 @@ class App extends React.Component {
     return (
 
       <section className='app'>
-        <ImageGallery
-          ref={i => this._imageGallery = i}
-          items={this.images}
-          lazyLoad={false}
-          onClick={this._onImageClick.bind(this)}
-          onImageLoad={this._onImageLoad}
-          onSlide={this._onSlide.bind(this)}
-          onPause={this._onPause.bind(this)}
-          onScreenChange={this._onScreenChange.bind(this)}
-          onPlay={this._onPlay.bind(this)}
-          infinite={this.state.infinite}
-          showBullets={this.state.showBullets}
-          showFullscreenButton={this.state.showFullscreenButton && this.state.showGalleryFullscreenButton}
-          showPlayButton={this.state.showPlayButton && this.state.showGalleryPlayButton}
-          showThumbnails={this.state.showThumbnails}
-          showIndex={this.state.showIndex}
-          showNav={this.state.showNav}
-          isRTL={this.state.isRTL}
-          thumbnailPosition={this.state.thumbnailPosition}
-          slideDuration={parseInt(this.state.slideDuration)}
-          slideInterval={parseInt(this.state.slideInterval)}
-          slideOnThumbnailOver={this.state.slideOnThumbnailOver}
-          additionalClass="app-image-gallery"
-        />
+        <div ref={this.wrapperRef}>
+          <ImageGallery
+            ref={i => this._imageGallery = i}
+            items={this.images}
+            lazyLoad={false}
+            onClick={this._onImageClick.bind(this)}
+            onImageLoad={this._onImageLoad}
+            onSlide={this._onSlide.bind(this)}
+            onPause={this._onPause.bind(this)}
+            onScreenChange={this._onScreenChange.bind(this)}
+            onPlay={this._onPlay.bind(this)}
+            infinite={this.state.infinite}
+            showBullets={this.state.showBullets}
+            showFullscreenButton={this.state.showFullscreenButton && this.state.showGalleryFullscreenButton}
+            showPlayButton={this.state.showPlayButton && this.state.showGalleryPlayButton}
+            showThumbnails={this.state.showThumbnails}
+            showIndex={this.state.showIndex}
+            showNav={this.state.showNav}
+            isRTL={this.state.isRTL}
+            thumbnailPosition={this.state.thumbnailPosition}
+            slideDuration={parseInt(this.state.slideDuration)}
+            slideInterval={parseInt(this.state.slideInterval)}
+            slideOnThumbnailOver={this.state.slideOnThumbnailOver}
+            additionalClass="app-image-gallery"
+            disableKeyDown={this.state.disableKeyDown}
+          />
+        </div>
 
         <div className='app-sandbox'>
 
@@ -255,6 +288,24 @@ class App extends React.Component {
                     <option value='left'>Left</option>
                     <option value='right'>Right</option>
                   </select>
+                </div>
+              </li>
+              <li>
+                <div className='app-interval-input-group'>
+                  <span className='app-interval-label'>Disable Key Down Conditions</span>
+                  <select
+                    className='app-interval-input'
+                    onChange={this._handleDisableKeyDownControl.bind(this)}
+                  >
+                    <option value='false'>Never</option>
+                    <option value='true'>Always</option>
+                    <option value='focusOutsideGallery'>Focus outside Gallery</option>
+                    <option value='focusInInputs'>Any Inputs focused</option>
+                  </select>
+                  {
+                    this.state.disableKeyDownChoice === 'focusInInputs' &&
+                    <input placeholder='(try focusing here)' />
+                  }
                 </div>
               </li>
             </ul>
@@ -334,7 +385,6 @@ class App extends React.Component {
               </li>
             </ul>
           </div>
-
         </div>
       </section>
     );

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -12,6 +12,7 @@ import {
   node,
   number,
   oneOf,
+  oneOfType,
   shape,
   string,
 } from 'prop-types';
@@ -69,7 +70,7 @@ export default class ImageGallery extends React.Component {
     showPlayButton: bool,
     showFullscreenButton: bool,
     disableThumbnailScroll: bool,
-    disableKeyDown: bool,
+    disableKeyDown: oneOfType([bool, func]),
     disableSwipe: bool,
     useBrowserFullscreen: bool,
     preventDefaultTouchmoveEvent: bool,
@@ -905,7 +906,9 @@ export default class ImageGallery extends React.Component {
     // keep track of mouse vs keyboard usage for a11y
     this.imageGallery.current.classList.remove('image-gallery-using-mouse');
 
-    if (disableKeyDown) return;
+    if (
+      typeof disableKeyDown === 'function' ? disableKeyDown(event) : disableKeyDown
+    ) return;
     const LEFT_ARROW = 37;
     const RIGHT_ARROW = 39;
     const ESC_KEY = 27;


### PR DESCRIPTION
# Motivation
In our app, we found that left/right arrow keydown events switched between images when users were moved their cursors in text inputs. Our desired behavior is that the keydown events change between images as long as no control outside the gallery has focus. This feature is not supported by react-image-gallery and is added by this PR.

Note that this is similar to another PR: https://github.com/xiaolin/react-image-gallery/pull/518. My PR accomplishes the behavior desired in that PR as a special case, and I have demonstrated it as an example in the example app.

# Implementation
We support arbitrary conditions for disabling key down handling by allowing the `disableKeyDown` prop to be a function that we call with the keydown event object to allow client code to determine exactly when the event should affect the gallery.