### PR TITLE
Add aria label to image-gallery-slide

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -624,6 +624,7 @@ export default class ImageGallery extends React.Component {
 
       const slide = (
         <div
+          aria-label={`Go to Slide ${index + 1}`}
           key={`slide-${item.original}-${index}`}
           tabIndex="-1"
           className={`image-gallery-slide ${alignment} ${originalClass}`}


### PR DESCRIPTION
Fix for #525 

#### What does this PR do?

Adds `aria-label` to the item renderer for `image-gallery-slide`. Because of `role="button"` it is an accessibility violation to not have an aria-readable label. This fixes that problem.

#### Notes

I have used VSCode and it insists on updating the formatting on the other files. This seems consistent to me so it should probably be kept.