### PR TITLE
expose window resize event

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -95,6 +95,7 @@ export default class ImageGallery extends React.Component {
     onTouchStart: func,
     onMouseOver: func,
     onMouseLeave: func,
+    onWindowResize: func,
     onThumbnailError: func,
     onThumbnailClick: func,
     renderCustomControls: func,
@@ -149,6 +150,7 @@ export default class ImageGallery extends React.Component {
     onTouchStart: null,
     onMouseOver: null,
     onMouseLeave: null,
+    onWindowResize: null,
     onThumbnailError: null,
     onThumbnailClick: null,
     renderCustomControls: null,
@@ -951,6 +953,7 @@ export default class ImageGallery extends React.Component {
 
   handleResize() {
     const { currentIndex } = this.state;
+    const { onWindowResize } = this.props;
     if (this.imageGallery && this.imageGallery.current) {
       this.setState({ galleryWidth: this.imageGallery.current.offsetWidth });
     }
@@ -966,6 +969,10 @@ export default class ImageGallery extends React.Component {
         this.setState({ thumbnailsWrapperHeight: this.thumbnailsWrapper.current.offsetHeight });
       } else {
         this.setState({ thumbnailsWrapperWidth: this.thumbnailsWrapper.current.offsetWidth });
+      }
+
+      if (onWindowResize) {
+        onWindowResize(this.thumbnailsWrapper.current.offsetWidth, this.thumbnailsWrapper.current.offsetHeight);
       }
     }
 

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -970,10 +970,10 @@ export default class ImageGallery extends React.Component {
       } else {
         this.setState({ thumbnailsWrapperWidth: this.thumbnailsWrapper.current.offsetWidth });
       }
+    }
 
-      if (onWindowResize) {
-        onWindowResize(this.thumbnailsWrapper.current.offsetWidth, this.thumbnailsWrapper.current.offsetHeight);
-      }
+    if (this.thumbnailsWrapper && this.thumbnailsWrapper.current && onWindowResize) {
+      onWindowResize(this.state);
     }
 
     // Adjust thumbnail container when thumbnail width or height is adjusted


### PR DESCRIPTION
Hi, Currently utilising this for a project and its great, very flexible but hit my first wall when trying to add a thumbnail scroller/pager (not swipable). I need the resize event to calculate max number of thumbnails in the scroller. I can add a resize hook outside of carousel but it would be great if I could use the already existing event emitted from carousel itself - this is my attempt, unfortunately low on time so this is more a sketch as I can't get build working ootb. However I think it would work and cant see any conflict with existing functionality so would love to merge in? in a rush so might have to get forked version working if not Thank you