### PR TITLE
Adding react v17 as a peer dependency!

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "watchify": "^3.8.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "clsx": "^1.0.4",


### PR DESCRIPTION
This pull request is intended to fix the following warning,
react-image-gallery@1.0.8" has incorrect peer dependency "react@^16.0.0".