### PR TITLE
Feature/fix for passive event listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.8",
-    "react-swipeable": "^5.2.0",
+    "react-swipeable": "6.0.1",
     "resize-observer-polyfill": "^1.5.0"
   }
 }

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
-import { Swipeable, LEFT, RIGHT } from 'react-swipeable';
+import { LEFT, RIGHT } from 'react-swipeable';
 import throttle from 'lodash.throttle';
 import debounce from 'lodash.debounce';
 import isEqual from 'lodash.isequal';
@@ -16,6 +16,7 @@ import {
   string,
 } from 'prop-types';
 import SVG from './SVG';
+import SwipeWrapper from './SwipeWrapper';
 
 const screenChangeEvents = [
   'fullscreenchange',
@@ -1389,16 +1390,13 @@ export default class ImageGallery extends React.Component {
                   </React.Fragment>
                 )
               }
-              <Swipeable
+              <SwipeWrapper
                 className="image-gallery-swipe"
                 delta={0}
                 onSwiping={this.handleSwiping}
                 onSwiped={this.handleOnSwiped}
-              >
-                <div className="image-gallery-slides">
-                  {slides}
-                </div>
-              </Swipeable>
+                slides={slides}
+              />
             </React.Fragment>
           ) : (
             <div className="image-gallery-slides">

--- a/src/SwipeWrapper.jsx
+++ b/src/SwipeWrapper.jsx
@@ -8,7 +8,7 @@ import {
 } from 'prop-types';
 import { useSwipeable } from 'react-swipeable';
 
-const SwipeableWrapper = ({
+const SwipeWrapper = ({
   slides,
   className,
   delta,
@@ -21,24 +21,24 @@ const SwipeableWrapper = ({
     onSwiping,
     onSwiped,
   });
-  if (slides && slides.length) {
-    return (
-      <div {...swipeHandlers} className="image-gallery-slides">
-        {slides}
-      </div>
-    );
-  }
-  return null;
+  return (
+    <div {...swipeHandlers} className="image-gallery-slides">
+      {slides}
+    </div>
+  );
 };
-SwipeableWrapper.propTypes = {
-  slides: arrayOf(shape({})).isRequired,
+SwipeWrapper.propTypes = {
+  slides: arrayOf(shape({})),
   className: string,
   delta: number,
-  onSwiped: func.isRequired,
-  onSwiping: func.isRequired,
+  onSwiped: func,
+  onSwiping: func,
 };
-SwipeableWrapper.defaultProps = {
+SwipeWrapper.defaultProps = {
   className: '',
   delta: 0,
+  slides: [],
+  onSwiping: () => {},
+  onSwiped: () => {},
 };
-export default SwipeableWrapper;
+export default SwipeWrapper;

--- a/src/SwipeWrapper.jsx
+++ b/src/SwipeWrapper.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  shape,
+  string,
+  number,
+  func,
+  arrayOf,
+} from 'prop-types';
+import { useSwipeable } from 'react-swipeable';
+
+const SwipeableWrapper = ({
+  slides,
+  className,
+  delta,
+  onSwiping,
+  onSwiped,
+}) => {
+  const swipeHandlers = useSwipeable({
+    className,
+    delta,
+    onSwiping,
+    onSwiped,
+  });
+  if (slides && slides.length) {
+    return (
+      <div {...swipeHandlers} className="image-gallery-slides">
+        {slides}
+      </div>
+    );
+  }
+  return null;
+};
+SwipeableWrapper.propTypes = {
+  slides: arrayOf(shape({})).isRequired,
+  className: string,
+  delta: number,
+  onSwiped: func.isRequired,
+  onSwiping: func.isRequired,
+};
+SwipeableWrapper.defaultProps = {
+  className: '',
+  delta: 0,
+};
+export default SwipeableWrapper;


### PR DESCRIPTION
The following PR includes removing the passive event listener warning that is coming on the lighthouse report. This warning was caused by react-swipeable and has been fixed in v6. 

This issue was mentioned in https://github.com/xiaolin/react-image-gallery/issues/510 

To fix the issue on react-image-gallery, the package for react-swipeable has been updated to v6.0.1 and a SwipeWrapper has been created that uses the useSwipeable hook. 
The SwipeWrapper component takes in the following props
1. slides: the array of JSX that needs to be rendered.
2. className: the name that needs to be present on the swipeHandler
3. delta
4. onSwiping
5. onSwiped  