### PR TITLE
Image & thumbnail: add loading param

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ class MyGallery extends React.Component {
     * `fullscreen` - image for fullscreen (defaults to original)
     * `originalHeight` - image height (html5 attribute)
     * `originalWidth` - image width (html5 attribute)
+    * `loading` - image loading. Either "lazy" or "eager" (html5 attribute)
     * `thumbnailHeight` - image height (html5 attribute)
     * `thumbnailWidth` - image width (html5 attribute)
+    * `thumbnailLoading` - image loading. Either "lazy" or "eager" (html5 attribute)
     * `originalClass` - custom image class
     * `thumbnailClass` - custom thumbnail class
     * `renderItem` - Function for custom rendering a specific slide (see renderItem below)

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -1268,6 +1268,7 @@ class ImageGallery extends React.Component {
         originalWidth={item.originalWidth}
         originalTitle={item.originalTitle}
         sizes={item.sizes}
+        loading={item.loading}
         srcSet={item.srcSet}
       />
     );
@@ -1286,6 +1287,7 @@ class ImageGallery extends React.Component {
           width={item.thumbnailWidth}
           alt={item.thumbnailAlt}
           title={item.thumbnailTitle}
+          loading={item.thumbnailLoading}
           onError={handleThumbnailError}
         />
         {
@@ -1454,8 +1456,10 @@ ImageGallery.propTypes = {
     original: string,
     originalHeight: number,
     originalWidth: number,
+    loading: string,
     thumbnailHeight: number,
     thumbnailWidth: number,
+    thumbnailLoading: string,
     fullscreen: string,
     originalAlt: string,
     originalTitle: string,

--- a/src/Item.js
+++ b/src/Item.js
@@ -14,6 +14,7 @@ const Item = React.memo(({
   originalTitle,
   sizes,
   srcSet,
+  loading,
 }) => {
   const itemSrc = isFullscreen ? (fullscreen || original) : original;
 
@@ -30,6 +31,7 @@ const Item = React.memo(({
         title={originalTitle}
         onLoad={event => handleImageLoaded(event, original)}
         onError={onImageError}
+        loading={loading}
       />
       {
         description && (
@@ -57,6 +59,7 @@ Item.propTypes = {
   originalTitle: string,
   sizes: string,
   srcSet: string,
+  loading: string,
 };
 
 Item.defaultProps = {
@@ -69,6 +72,7 @@ Item.defaultProps = {
   originalTitle: '',
   sizes: '',
   srcSet: '',
+  loading: 'eager',
 };
 
 export default Item;


### PR DESCRIPTION
Add `loading` param to all image tags.

The `loading` param can be used in img tags to use native lazy load by adding `loading=“lazy”`. This means browsers will only start loading image when it appears on the screen. Nowadays Google Lighthouse / Insights scores pages negatively if images below the fold are not lazyloaded.

Changes:
- Add “loading” parameter to item. Will either default to “eager” (=html default, preserves existing behavior), or user can set it to “lazy”
- Add “thumbnailLoading” parameter to item. Same behavior, user can set thumbnails to lazyload
- Add mentions of these new parameters to readme

I would’ve like to add a test case for this, but the current test command & setup do not seem to work. Something about Jest not liking one of lodash dependencies. I checked this with the example app to confirm the lazyload parameters passed through.