### PR TITLE
Wrap thumbnails in `nav` tag to get proper ARIA role

### DIFF
--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -1427,14 +1427,14 @@ class ImageGallery extends React.Component {
                 onSwiped={!disableThumbnailSwipe && this.handleOnThumbnailSwiped}
               >
                 <div className="image-gallery-thumbnails" ref={this.thumbnailsWrapper} style={this.getThumbnailBarHeight()}>
-                  <div
+                  <nav
                     ref={this.thumbnails}
                     className="image-gallery-thumbnails-container"
                     style={thumbnailStyle}
                     aria-label="Thumbnail Navigation"
                   >
                     {thumbnails}
-                  </div>
+                  </nav>
                 </div>
               </SwipeWrapper>
             ) : null


### PR DESCRIPTION
While running an accessibility test on a project using this package we found the following error: `aria-label attribute is not well supported on a div with no valid role attribute`.

You could simply add a `role="navigation"` to the div, but changing the `div` to `nav` will do that and be more semantically correct.