### PR TITLE
Added Responsive thumbnail positions prop

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import ImageGallery from 'src/ImageGallery';
+// Import viewport utils method
+import getCurrentViewport from '../src/utils/getCurrentViewport';
 
 const PREFIX_URL = 'https://raw.githubusercontent.com/xiaolin/react-image-gallery/master/static/';
 
@@ -23,7 +25,8 @@ class App extends React.Component {
       slideDuration: 450,
       slideInterval: 2000,
       slideOnThumbnailOver: false,
-      thumbnailPosition: 'bottom',
+      // Set viewports thumbnail positions as desired
+      thumbnailPositions: { 'xs': 'top', 'sm': 'bottom', 'md': 'bottom', 'lg': 'left', 'xl': 'right', '2xl': 'left' },
       showVideo: {},
       useWindowKeyDown: true,
     };
@@ -82,7 +85,10 @@ class App extends React.Component {
   }
 
   _handleThumbnailPositionChange(event) {
-    this.setState({thumbnailPosition: event.target.value});
+    // Update thumbnail position object with position set from input field
+    const newPositionsObject = { ...this.state.thumbnailPositions }
+    newPositionsObject[getCurrentViewport()] = event.target.value
+    this.setState({thumbnailPositions: newPositionsObject});
   }
 
   _getStaticImages() {
@@ -186,7 +192,7 @@ class App extends React.Component {
           showIndex={this.state.showIndex}
           showNav={this.state.showNav}
           isRTL={this.state.isRTL}
-          thumbnailPosition={this.state.thumbnailPosition}
+          thumbnailPositions={this.state.thumbnailPositions}
           slideDuration={parseInt(this.state.slideDuration)}
           slideInterval={parseInt(this.state.slideInterval)}
           slideOnThumbnailOver={this.state.slideOnThumbnailOver}
@@ -227,7 +233,7 @@ class App extends React.Component {
                   <span className='app-interval-label'>Thumbnail Bar Position</span>
                   <select
                     className='app-interval-input'
-                    value={this.state.thumbnailPosition}
+                    value={this.state.thumbnailPositions[getCurrentViewport()]}
                     onChange={this._handleThumbnailPositionChange.bind(this)}
                   >
                     <option value='bottom'>Bottom</option>

--- a/src/utils/getCurrentViewport.js
+++ b/src/utils/getCurrentViewport.js
@@ -1,0 +1,24 @@
+export default function getCurrentViewport() {
+  let viewport;
+  let e = window, a = 'inner';
+  if (!( 'innerWidth' in window )){
+    a = 'client';
+    e = document.documentElement || document.body;
+  }
+  const dimension = { width : e[ a + 'Width' ] , height : e[ a + 'Height' ] }
+  if (dimension.width >= 1536) {
+    viewport = '2xl';
+  } else if (dimension.width >= 1280 && dimension.width < 1536) {
+    viewport = 'xl';
+  } else if (dimension.width >= 1024 && dimension.width < 1280) {
+    viewport = 'lg';
+  } else if (dimension.width >= 768 && dimension.width < 1024) {
+    viewport = 'md';
+  } else if (dimension.width >= 640 && dimension.width < 768) {
+    viewport = 'sm';
+  } else if (dimension.width < 640) {
+    viewport = 'xs'
+  }
+  console.log(dimension.width)
+  return viewport;
+}

--- a/src/utils/getCurrentViewport.js
+++ b/src/utils/getCurrentViewport.js
@@ -19,6 +19,5 @@ export default function getCurrentViewport() {
   } else if (dimension.width < 640) {
     viewport = 'xs'
   }
-  console.log(dimension.width)
   return viewport;
 }


### PR DESCRIPTION
I used `react-image-gallery` some days ago and really loved it for the thumbnail position feature because it fitted my need at the moment. I later realized I didn't like the compact display on mobile devices since I had initially set my thumbnail position to `left`. The image in the main slider wasn't large enough.
I created a custom method to have it adapt and be responsive the way I desired and thought it necessary to give back to this awesome team.

### Modifications
`thumbnailPosition` prop is now `thumbnailPositions`
New prop `thumbnailPositions` is of type `object` and contains multiple positions with viewport sizes as `keys`

### Example
```
<ImageGallery
...
thumbnailPositions={ { 'xs': 'bottom', 'sm': 'top', 'md': 'left', 'lg': 'right', 'xl': 'right', '2xl': 'left' } }
...
```
**Note:** Default thumbnail position is `bottom` and `thumbnailPositions` object could be limited to the viewports you care about changing thumbnail position.

For instance, the implementation below would set the thumbnail position to default (`bottom`) for `md` and `2xl` viewport sizes as their positions are not provided for in the prop.

```
<ImageGallery
...
thumbnailPositions={ { 'xs': 'bottom', 'sm': 'top', 'lg': 'right', 'xl': 'right' } }
...
```

**Footnote:** No new dependencies are required