### PR TITLE
Added navigation arrows to thumbnails

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -14,6 +14,7 @@ class App extends React.Component {
       showBullets: true,
       infinite: true,
       showThumbnails: true,
+      showThumbnailsNav: false,
       showFullscreenButton: true,
       showGalleryFullscreenButton: true,
       showPlayButton: true,
@@ -183,6 +184,7 @@ class App extends React.Component {
           showFullscreenButton={this.state.showFullscreenButton && this.state.showGalleryFullscreenButton}
           showPlayButton={this.state.showPlayButton && this.state.showGalleryPlayButton}
           showThumbnails={this.state.showThumbnails}
+          showThumbnailsNav={this.state.showThumbnailsNav}
           showIndex={this.state.showIndex}
           showNav={this.state.showNav}
           isRTL={this.state.isRTL}
@@ -279,6 +281,14 @@ class App extends React.Component {
                   onChange={this._handleCheckboxChange.bind(this, 'showThumbnails')}
                   checked={this.state.showThumbnails}/>
                   <label htmlFor='show_thumbnails'>show thumbnails</label>
+              </li>
+              <li>
+                <input
+                  id='show_thumbnails_nav'
+                  type='checkbox'
+                  onChange={this._handleCheckboxChange.bind(this, 'showThumbnailsNav')}
+                  checked={this.state.showThumbnailsNav}/>
+                  <label htmlFor='show_thumbnails_nav'>show thumbs navigation</label>
               </li>
               <li>
                 <input

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -1324,6 +1324,7 @@ class ImageGallery extends React.Component {
       thumbnailPosition,
       renderFullscreenButton,
       renderCustomControls,
+      renderThumbnailsCustomControls,
       renderLeftNav,
       renderRightNav,
       renderThumbnailsTopNav,
@@ -1443,6 +1444,8 @@ class ImageGallery extends React.Component {
                 onSwiped={!disableThumbnailSwipe && this.handleOnThumbnailSwiped}
               >
                 <div className="image-gallery-thumbnails" ref={this.thumbnailsWrapper} style={this.getThumbnailBarHeight()}>
+                  {/* Render thumbnails custom controls */}
+                  {renderThumbnailsCustomControls && renderThumbnailsCustomControls()}
                   {/* Show thumbnails navigation */}
                   {
                     showThumbnailsNav && (thumbnailPosition === 'top' || thumbnailPosition === 'bottom') && (
@@ -1551,6 +1554,7 @@ ImageGallery.propTypes = {
   onThumbnailError: func,
   onThumbnailClick: func,
   renderCustomControls: func,
+  renderThumbnailsCustomControls: func,
   renderLeftNav: func,
   renderRightNav: func,
   renderThumbnailsTopNav: func,
@@ -1612,6 +1616,7 @@ ImageGallery.defaultProps = {
   onThumbnailError: null,
   onThumbnailClick: null,
   renderCustomControls: null,
+  renderThumbnailsCustomControls: null,
   renderThumbInner: null,
   renderItem: null,
   slideInterval: 3000,

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -1326,6 +1326,7 @@ class ImageGallery extends React.Component {
       showFullscreenButton,
       showIndex,
       showThumbnails,
+      showThumbnailsNav,
       showNav,
       showPlayButton,
       renderPlayPauseButton,
@@ -1429,6 +1430,14 @@ class ImageGallery extends React.Component {
                 onSwiped={!disableThumbnailSwipe && this.handleOnThumbnailSwiped}
               >
                 <div className="image-gallery-thumbnails" ref={this.thumbnailsWrapper} style={this.getThumbnailBarHeight()}>
+                  {
+                    showThumbnailsNav && (
+                      <React.Fragment>
+                        {renderLeftNav(this.slideLeft, !this.canSlideLeft())}
+                        {renderRightNav(this.slideRight, !this.canSlideRight())}
+                      </React.Fragment>
+                    )
+                  }
                   <nav
                     ref={this.thumbnails}
                     className="image-gallery-thumbnails-container"
@@ -1484,6 +1493,7 @@ ImageGallery.propTypes = {
   showIndex: bool,
   showBullets: bool,
   showThumbnails: bool,
+  showThumbnailsNav: bool,
   showPlayButton: bool,
   showFullscreenButton: bool,
   disableThumbnailScroll: bool,
@@ -1540,6 +1550,7 @@ ImageGallery.defaultProps = {
   showIndex: false,
   showBullets: false,
   showThumbnails: true,
+  showThumbnailsNav: false,
   showPlayButton: true,
   showFullscreenButton: true,
   disableThumbnailScroll: false,

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -25,6 +25,10 @@ import LeftNav from 'src/controls/LeftNav';
 import RightNav from 'src/controls/RightNav';
 import PlayPause from 'src/controls/PlayPause';
 import SwipeWrapper from 'src/SwipeWrapper';
+import ThumbnailsLeftNav from 'src/controls/ThumbnailsLeftNav';
+import ThumbnailsRightNav from 'src/controls/ThumbnailsRightNav';
+import ThumbnailsTopNav from 'src/controls/ThumbnailsTopNav';
+import ThumbnailsBottomNav from 'src/controls/ThumbnailsBottomNav';
 
 const screenChangeEvents = [
   'fullscreenchange',
@@ -1322,6 +1326,10 @@ class ImageGallery extends React.Component {
       renderCustomControls,
       renderLeftNav,
       renderRightNav,
+      renderThumbnailsTopNav,
+      renderThumbnailsBottomNav,
+      renderThumbnailsLeftNav,
+      renderThumbnailsRightNav,
       showBullets,
       showFullscreenButton,
       showIndex,
@@ -1413,6 +1421,10 @@ class ImageGallery extends React.Component {
       { 'thumbnails-swipe-horizontal': !this.isThumbnailVertical() && !disableThumbnailSwipe },
       { 'thumbnails-swipe-vertical': this.isThumbnailVertical() && !disableThumbnailSwipe },
     );
+    const thumbnailsLimiterClass = clsx(
+      'image-gallery-thumbnails-limiter',
+      { 'thumbnails-nav-showed': showThumbnailsNav },
+    )
     return (
       <div
         ref={this.imageGallery}
@@ -1431,21 +1443,31 @@ class ImageGallery extends React.Component {
               >
                 <div className="image-gallery-thumbnails" ref={this.thumbnailsWrapper} style={this.getThumbnailBarHeight()}>
                   {
-                    showThumbnailsNav && (
+                    showThumbnailsNav && (thumbnailPosition === 'top' || thumbnailPosition === 'bottom') && (
                       <React.Fragment>
-                        {renderLeftNav(this.slideLeft, !this.canSlideLeft())}
-                        {renderRightNav(this.slideRight, !this.canSlideRight())}
+                        {renderThumbnailsLeftNav(this.slideLeft, !this.canSlideLeft())}
+                        {renderThumbnailsRightNav(this.slideRight, !this.canSlideRight())}
                       </React.Fragment>
                     )
                   }
-                  <nav
-                    ref={this.thumbnails}
-                    className="image-gallery-thumbnails-container"
-                    style={thumbnailStyle}
-                    aria-label="Thumbnail Navigation"
-                  >
-                    {thumbnails}
-                  </nav>
+                  {
+                    showThumbnailsNav && (thumbnailPosition === 'left' || thumbnailPosition === 'right') && (
+                      <React.Fragment>
+                        {renderThumbnailsTopNav(this.slideLeft, !this.canSlideLeft())}
+                        {renderThumbnailsBottomNav(this.slideRight, !this.canSlideRight())}
+                      </React.Fragment>
+                    )
+                  }
+                  <div className={thumbnailsLimiterClass}>
+                    <nav
+                      ref={this.thumbnails}
+                      className="image-gallery-thumbnails-container"
+                      style={thumbnailStyle}
+                      aria-label="Thumbnail Navigation"
+                    >
+                      {thumbnails}
+                    </nav>
+                  </div>
                 </div>
               </SwipeWrapper>
             ) : null
@@ -1529,6 +1551,10 @@ ImageGallery.propTypes = {
   renderCustomControls: func,
   renderLeftNav: func,
   renderRightNav: func,
+  renderThumbnailsTopNav: func,
+  renderThumbnailsBottomNav: func,
+  renderThumbnailsLeftNav: func,
+  renderThumbnailsRightNav: func,
   renderPlayPauseButton: func,
   renderFullscreenButton: func,
   renderItem: func,
@@ -1594,6 +1620,18 @@ ImageGallery.defaultProps = {
   ),
   renderRightNav: (onClick, disabled) => (
     <RightNav onClick={onClick} disabled={disabled} />
+  ),
+  renderThumbnailsTopNav: (onClick, disabled) => (
+    <ThumbnailsTopNav onClick={onClick} disabled={disabled} />
+  ),
+  renderThumbnailsBottomNav: (onClick, disabled) => (
+    <ThumbnailsBottomNav onClick={onClick} disabled={disabled} />
+  ),
+  renderThumbnailsLeftNav: (onClick, disabled) => (
+    <ThumbnailsLeftNav onClick={onClick} disabled={disabled} />
+  ),
+  renderThumbnailsRightNav: (onClick, disabled) => (
+    <ThumbnailsRightNav onClick={onClick} disabled={disabled} />
   ),
   renderPlayPauseButton: (onClick, isPlaying) => (
     <PlayPause onClick={onClick} isPlaying={isPlaying} />

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -1421,6 +1421,7 @@ class ImageGallery extends React.Component {
       { 'thumbnails-swipe-horizontal': !this.isThumbnailVertical() && !disableThumbnailSwipe },
       { 'thumbnails-swipe-vertical': this.isThumbnailVertical() && !disableThumbnailSwipe },
     );
+    // Add class if thumbnails navigation are showed
     const thumbnailsLimiterClass = clsx(
       'image-gallery-thumbnails-limiter',
       { 'thumbnails-nav-showed': showThumbnailsNav },
@@ -1442,6 +1443,7 @@ class ImageGallery extends React.Component {
                 onSwiped={!disableThumbnailSwipe && this.handleOnThumbnailSwiped}
               >
                 <div className="image-gallery-thumbnails" ref={this.thumbnailsWrapper} style={this.getThumbnailBarHeight()}>
+                  {/* Show thumbnails navigation */}
                   {
                     showThumbnailsNav && (thumbnailPosition === 'top' || thumbnailPosition === 'bottom') && (
                       <React.Fragment>

--- a/src/SVG.js
+++ b/src/SVG.js
@@ -3,6 +3,8 @@ import { number, oneOf, string } from 'prop-types';
 
 const left = <polyline points="15 18 9 12 15 6" />;
 const right = <polyline points="9 18 15 12 9 6" />;
+const top = <polyline points="19.326 14.81 13.68 9.026 7.674 14.81" />;
+const bottom = <polyline points="19.323 9 13.677 15 7.677 9" />
 const maximize = <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />;
 const minimize = <path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />;
 const play = <polygon points="5 3 19 12 5 21 5 3" />;
@@ -16,6 +18,8 @@ const pause = (
 const iconMapper = {
   left,
   right,
+  top,
+  bottom,
   maximize,
   minimize,
   play,
@@ -50,6 +54,8 @@ SVG.propTypes = {
   icon: oneOf([
     'left',
     'right',
+    'top',
+    'bottom',
     'maximize',
     'minimize',
     'play',

--- a/src/controls/ThumbnailsBottomNav.js
+++ b/src/controls/ThumbnailsBottomNav.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import SVG from 'src/SVG';
+
+const ThumbnailsBottomNav = React.memo(({
+  disabled,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      className="image-gallery-icon thumbnails-bottom-nav"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label="Next Slide"
+    >
+      <SVG icon="bottom" viewBox="6 7 15 10" />
+    </button>
+  );
+});
+
+ThumbnailsBottomNav.displayName = 'ThumbnailsBottomNav';
+
+ThumbnailsBottomNav.propTypes = {
+  disabled: bool.isRequired,
+  onClick: func.isRequired,
+};
+
+
+export default ThumbnailsBottomNav;

--- a/src/controls/ThumbnailsLeftNav.js
+++ b/src/controls/ThumbnailsLeftNav.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import SVG from 'src/SVG';
+
+const ThumbnailsLeftNav = React.memo(({
+  disabled,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      className="image-gallery-icon thumbnails-left-nav"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label="Previous Slide"
+    >
+      <SVG icon="left" viewBox="6 0 12 24" />
+    </button>
+  );
+});
+
+ThumbnailsLeftNav.displayName = 'ThumbnailsLeftNav';
+
+ThumbnailsLeftNav.propTypes = {
+  disabled: bool.isRequired,
+  onClick: func.isRequired,
+};
+
+
+export default ThumbnailsLeftNav;

--- a/src/controls/ThumbnailsRightNav.js
+++ b/src/controls/ThumbnailsRightNav.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import SVG from 'src/SVG';
+
+const ThumbnailsRightNav = React.memo(({
+  disabled,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      className="image-gallery-icon thumbnails-right-nav"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label="Next Slide"
+    >
+      <SVG icon="right" viewBox="6 0 12 24" />
+    </button>
+  );
+});
+
+ThumbnailsRightNav.displayName = 'ThumbnailsRightNav';
+
+ThumbnailsRightNav.propTypes = {
+  disabled: bool.isRequired,
+  onClick: func.isRequired,
+};
+
+
+export default ThumbnailsRightNav;

--- a/src/controls/ThumbnailsTopNav.js
+++ b/src/controls/ThumbnailsTopNav.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import SVG from 'src/SVG';
+
+const ThumbnailsTopNav = React.memo(({
+  disabled,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      className="image-gallery-icon thumbnails-top-nav"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label="Previous Slide"
+    >
+      <SVG icon="top" viewBox="6 7 15 10" />
+    </button>
+  );
+});
+
+ThumbnailsTopNav.displayName = 'ThumbnailsTopNav';
+
+ThumbnailsTopNav.propTypes = {
+  disabled: bool.isRequired,
+  onClick: func.isRequired,
+};
+
+
+export default ThumbnailsTopNav;

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -397,6 +397,7 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 
     }
 
+    // Give space to thumbnails navigation
     .thumbnails-nav-showed {
       height: 75%;
       margin-top: 65px;
@@ -414,6 +415,8 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
   }
   &.top,
   &.bottom {
+    // Give space to thumbnails navigation
+    // when positions are top or bottom
     .thumbnails-nav-showed {
       width: 88%;
       overflow: hidden;

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -125,6 +125,65 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 .image-gallery-right-nav {
   right: 0;
 }
+
+// Start of thumbnails icons styles
+.thumbnails-left-nav,
+.thumbnails-right-nav,
+.thumbnails-top-nav,
+.thumbnails-bottom-nav {
+  padding: 5px;
+
+  .image-gallery-svg {
+    height: 50px;
+    width: 50px;
+  }
+
+  @media (max-width: $ig-small-screen) {
+    .image-gallery-svg {
+      height: 40px;
+      width: 40px;
+    }
+  }
+
+  @media (max-width: $ig-xsmall-screen) {
+    .image-gallery-svg {
+      height: 30px;
+      width: 30px;
+    }
+  }
+
+  &[disabled] {
+    cursor: disabled;
+    opacity: .6;
+    pointer-events: none;
+  }
+}
+
+.thumbnails-left-nav,
+.thumbnails-right-nav {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.thumbnails-left-nav {
+  left: 0;
+}
+
+.thumbnails-right-nav {
+  right: 0;
+}
+.thumbnails-top-nav, 
+.thumbnails-bottom-nav {
+  left: 50%;
+  transform: translateX(-50%);
+}
+.thumbnails-top-nav {
+  top: 0;
+}
+.thumbnails-bottom-nav {
+  bottom: 0;
+}
+// End of thumbnails icons styles
 // End of Icon styles
 
 .image-gallery {
@@ -337,6 +396,12 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
       }
 
     }
+
+    .thumbnails-nav-showed {
+      height: 75%;
+      margin-top: 65px;
+      overflow: hidden;
+    }
   }
 
   &.left,
@@ -345,6 +410,14 @@ $ig-shadow: 0 2px 2px lighten($ig-black, 10%);
 
     @media (max-width: $ig-small-screen) {
       margin: 0 3px;
+    }
+  }
+  &.top,
+  &.bottom {
+    .thumbnails-nav-showed {
+      width: 88%;
+      overflow: hidden;
+      margin: auto;
     }
   }
 }


### PR DESCRIPTION
## Brief
I am in a project that needs to render arrows to thumbnails of the gallery. After browsing the documentation, I was unable to find a way to add properly navigation arrows to the thumbnails. I tried props like **renderThumbInner** or **renderCustomControls** but I could not get arrows to stick to the thumbnails wrapper. So, I added some components and functions to render them.

## Changes
- Added arrows components into **src/controls/** to differentiate from gallery navigation arrows
- Added corresponding styles into **image-gallery.scss**
- Rendered the components in **ImageGallery.js**
- Added custom controls prop for the thumbnails arrows
- Updated the example in **/example** folder

## Concerns
Currently, the dimension of thumbnails navigation are quite fixed in Sass. I would appreciate any suggestions that will help in solving that situation or anything related to the implementation of the thumbnails navigation arrows.

Regards, @Haja-dev.