### PR TITLE
Slide images vertically

### DIFF
--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -389,7 +389,7 @@ class ImageGallery extends React.Component {
   }
 
   getSlideStyle(index) {
-    const { currentIndex, currentSlideOffset, slideStyle } = this.state;
+    const { currentIndex, currentSlideOffset, slideStyle, slideVertically } = this.state;
     const {
       infinite,
       items,

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -60,7 +60,7 @@ class ImageGallery extends React.Component {
       isFullscreen: false,
       isSwipingThumbnail: false,
       isPlaying: false,
-      isVerticalSlide: props.isVerticalSlide
+      slideVertically: props.slideVertically
     };
     this.loadedImages = {};
     this.imageGallery = React.createRef();
@@ -420,10 +420,10 @@ class ImageGallery extends React.Component {
       translateX = this.getTranslateXForTwoSlide(index);
     }
 
-    let translate = `translate(${translateX}%, 0)`;
+    let translate = slideVertically ? `translate(0, ${translateX}%)` : `translate(${translateX}%, 0)`;
 
     if (useTranslate3D) {
-      translate = `translate3d(${translateX}%, 0, 0)`;
+      translate = slideVertically ? `translate3d(0, ${translateX}%, 0)` : `translate3d(${translateX}%, 0, 0)`;
     }
 
     // don't show some slides while transitioning to avoid background transitions
@@ -1533,7 +1533,7 @@ ImageGallery.propTypes = {
   useTranslate3D: bool,
   isRTL: bool,
   useWindowKeyDown: bool,
-  isVerticalSlide: bool
+  slideVertically: bool
 };
 
 ImageGallery.defaultProps = {
@@ -1597,7 +1597,7 @@ ImageGallery.defaultProps = {
     <Fullscreen onClick={onClick} isFullscreen={isFullscreen} />
   ),
   useWindowKeyDown: true,
-  isVerticalSlide: false
+  slideVertically: false
 };
 
 export default ImageGallery;

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -60,6 +60,7 @@ class ImageGallery extends React.Component {
       isFullscreen: false,
       isSwipingThumbnail: false,
       isPlaying: false,
+      isVerticalSlide: props.isVerticalSlide
     };
     this.loadedImages = {};
     this.imageGallery = React.createRef();
@@ -895,7 +896,7 @@ class ImageGallery extends React.Component {
 
     // If we can't swipe left or right, stay in the current index (noop)
     if ((swipeDirection === -1 && !this.canSlideLeft())
-        || (swipeDirection === 1 && !this.canSlideRight())) {
+      || (swipeDirection === 1 && !this.canSlideRight())) {
       slideTo = currentIndex;
     }
 
@@ -959,7 +960,7 @@ class ImageGallery extends React.Component {
 
   removeResizeObserver() {
     if (this.resizeObserver
-        && this.imageGallerySlideWrapper && this.imageGallerySlideWrapper.current) {
+      && this.imageGallerySlideWrapper && this.imageGallerySlideWrapper.current) {
       this.resizeObserver.unobserve(this.imageGallerySlideWrapper.current);
       this.resizeObserver = null;
     }
@@ -1532,6 +1533,7 @@ ImageGallery.propTypes = {
   useTranslate3D: bool,
   isRTL: bool,
   useWindowKeyDown: bool,
+  isVerticalSlide: bool
 };
 
 ImageGallery.defaultProps = {
@@ -1595,6 +1597,7 @@ ImageGallery.defaultProps = {
     <Fullscreen onClick={onClick} isFullscreen={isFullscreen} />
   ),
   useWindowKeyDown: true,
+  isVerticalSlide: false
 };
 
 export default ImageGallery;


### PR DESCRIPTION
## Description
Add functionality to enable transitioning between images vertically instead of horizontally.

## Changes
- Add new `slideVertically` prop
- Modify `translate` and `translate3d` values conditionally based on `slideVertically`