### PR TITLE
#655 Fixed: images slide above each other

### DIFF
--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -237,14 +237,15 @@ class ImageGallery extends React.Component {
 
   onThumbnailClick(event, index) {
     const { onThumbnailClick } = this.props;
+    const { currentIndex } = this.state;
     // blur element to remove outline cause by focus
     event.target.parentNode.parentNode.blur();
-   if(this.state.currentIndex!==index){
+   if(currentIndex!==index){
     this.slideToIndex(index, event);
-    if (onThumbnailClick) {
-      onThumbnailClick(event, index);
-    }
    }
+   if (onThumbnailClick) {
+    onThumbnailClick(event, index);
+  }
   }
 
   onThumbnailMouseOver(event, index) {

--- a/src/ImageGallery.js
+++ b/src/ImageGallery.js
@@ -239,10 +239,12 @@ class ImageGallery extends React.Component {
     const { onThumbnailClick } = this.props;
     // blur element to remove outline cause by focus
     event.target.parentNode.parentNode.blur();
+   if(this.state.currentIndex!==index){
     this.slideToIndex(index, event);
     if (onThumbnailClick) {
       onThumbnailClick(event, index);
     }
+   }
   }
 
   onThumbnailMouseOver(event, index) {


### PR DESCRIPTION
This PR resolves a known issue mentioned in https://github.com/xiaolin/react-image-gallery/issues/655

When there are only 2-3 images in the gallery, clicking on thumbnail causes the wrong image to slide over current image.