### PR TITLE
Index in second parameter in method handlerenderThumbInner

### DIFF
--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -643,7 +643,7 @@ class ImageGallery extends React.Component {
             onKeyUp={(event) => this.handleThumbnailKeyUp(event, index)}
             onClick={(event) => this.onThumbnailClick(event, index)}
           >
-            {handleRenderThumbInner(item)}
+            {handleRenderThumbInner(item, index)}
           </button>
         );
       }


### PR DESCRIPTION
### Description

As a UX requeriment for a project is it necessary to draw the index value in each thumbnails and is more convenient and easy to access to the index of each image in the `handlerenderThumbInner` method.

### Changes

- Add `index` value in second parameter of `handlerenderThumbInner` method .  

Check it by changing the source code of the example, override the method to draw the thumbnail  (`renderThumbInner`) and using the second parameter to show the number. I dont add that changes in the PR because I think it's not useful. 


![imagen](https://github.com/xiaolin/react-image-gallery/assets/2281075/d3c46fe5-cc28-49af-ac63-b7e9bf1c97b8)