### PR TITLE
Fix auto play direction in 2 slides

### DIFF
--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -1193,8 +1193,8 @@ class ImageGallery extends React.Component {
   }
 
   slideToIndex(index, event) {
-    const { currentIndex, isTransitioning } = this.state;
-    const { items, slideDuration, onBeforeSlide } = this.props;
+    const { currentIndex, isTransitioning, currentSlideOffset } = this.state;
+    const { items, slideDuration, onBeforeSlide, infinite } = this.props;
 
     if (!isTransitioning) {
       if (event) {
@@ -1217,16 +1217,35 @@ class ImageGallery extends React.Component {
         onBeforeSlide(nextIndex);
       }
 
-      this.setState(
-        {
-          previousIndex: currentIndex,
-          currentIndex: nextIndex,
-          isTransitioning: nextIndex !== currentIndex,
-          currentSlideOffset: 0,
-          slideStyle: { transition: `all ${slideDuration}ms ease-out` },
-        },
-        this.onSliding
-      );
+      const slideHandler = () => {
+        this.setState(
+          {
+            previousIndex: currentIndex,
+            currentIndex: nextIndex,
+            isTransitioning: nextIndex !== currentIndex,
+            currentSlideOffset: 0,
+            slideStyle: { transition: `all ${slideDuration}ms ease-out` },
+          },
+          this.onSliding
+        );
+      };
+
+      if (infinite && items.length === 2) {
+        this.setState(
+          {
+            // this will reset once index changes
+            currentSlideOffset:
+              currentSlideOffset + (currentIndex > index ? 0.001 : -0.001),
+            slideStyle: { transition: "none" }, // move the slide over instantly
+          },
+          () => {
+            // add 25ms timeout to avoid delay in moving slides over
+            window.setTimeout(slideHandler, 25);
+          }
+        );
+      } else {
+        slideHandler();
+      }
     }
   }
 
@@ -1242,36 +1261,11 @@ class ImageGallery extends React.Component {
 
   slideTo(event, direction) {
     const { currentIndex, isTransitioning } = this.state;
-    const { items } = this.props;
     const nextIndex = currentIndex + (direction === "left" ? -1 : 1);
 
     if (isTransitioning) return;
 
-    if (items.length === 2) {
-      this.slideToIndexWithStyleReset(nextIndex, event);
-    } else {
-      this.slideToIndex(nextIndex, event);
-    }
-  }
-
-  slideToIndexWithStyleReset(nextIndex, event) {
-    /*
-    When there are only 2 slides fake a tiny swipe to get the slides
-    on the correct side for transitioning
-    */
-    const { currentIndex, currentSlideOffset } = this.state;
-    this.setState(
-      {
-        // this will reset once index changes
-        currentSlideOffset:
-          currentSlideOffset + (currentIndex > nextIndex ? 0.001 : -0.001),
-        slideStyle: { transition: "none" }, // move the slide over instantly
-      },
-      () => {
-        // add 25ms timeout to avoid delay in moving slides over
-        window.setTimeout(() => this.slideToIndex(nextIndex, event), 25);
-      }
-    );
+    this.slideToIndex(nextIndex, event);
   }
 
   handleThumbnailMouseOver(event, index) {


### PR DESCRIPTION
This pr has fixed(not sure if it's) the swipe direction when there're 2 slides with infinite enabled.

Before this PR, when 2 slides only and `infinite` & `autoPlay` enabled, when playing from last slide to the first slide, the direction would be from RIGHT to LEFT:

![2024-02-01 20 58 10](https://github.com/xiaolin/react-image-gallery/assets/48507806/592ec751-ef92-4cc2-a221-02996c0c3913)

This seems to be correct, but remember when we swipe it manually then it works as 'infinite': the new slide always comes from the right side:

![2024-02-01 20 58 10](https://github.com/xiaolin/react-image-gallery/assets/48507806/b5be38db-d3a3-4863-8cca-c80b2c6a455a)

I think the swipe direction(or behaviour) should be same exactly whatever it's from auto play or user gesture? And this PR changes the behaviour in previous case to make it always works like 'infinite':

![2024-02-01 20 58 10](https://github.com/xiaolin/react-image-gallery/assets/48507806/adbeb9bd-6646-4881-b707-41403dfdaef2)

This PR doesnot make great changes, in opposite, I'm just putting the `slideToIndexWithStyleReset` into the `slideToIndex` handler, as all the slide changes goes through here.
