### PR TITLE
FIX: #767 . 

### DIFF
--- a/example/App.jsx
+++ b/example/App.jsx
@@ -175,6 +175,7 @@ class App extends React.Component {
     return (
       <section className="app">
         <ImageGallery
+        // renderLeftNav= {(onclick, disabled) => (<p onClick={onclick}>hello</p>)}
           ref={(i) => (this._imageGallery = i)}
           items={this.images}
           onClick={this._onImageClick.bind(this)}

--- a/example/App.jsx
+++ b/example/App.jsx
@@ -175,7 +175,6 @@ class App extends React.Component {
     return (
       <section className="app">
         <ImageGallery
-        // renderLeftNav= {(onclick, disabled) => (<p onClick={onclick}>hello</p>)}
           ref={(i) => (this._imageGallery = i)}
           items={this.images}
           onClick={this._onImageClick.bind(this)}

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -762,14 +762,16 @@ class ImageGallery extends React.Component {
     return items.length >= 2;
   }
 
+  //SOLVED BY hunxjunedo : https://github.com/xiaolin/react-image-gallery/issues/767
   canSlideLeft() {
-    const { infinite } = this.props;
-    return infinite || this.canSlidePrevious();
+    const { infinite, isRTL } = this.props;
+    //so basically is the list is right to left, the canSlideLeft depends on canSlideNext instead of canSlideRight
+    return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious());
   }
 
   canSlideRight() {
-    const { infinite } = this.props;
-    return infinite || this.canSlideNext();
+    const { infinite, isRTL } = this.props;
+    return infinite || (isRTL ? this.canSlidePrevious() : this.canSlideNext() )
   }
 
   canSlidePrevious() {
@@ -779,7 +781,7 @@ class ImageGallery extends React.Component {
 
   canSlideNext() {
     const { currentIndex } = this.state;
-    const { items } = this.props;
+    const { items, isRTL } = this.props;
     return currentIndex < items.length - 1;
   }
 

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -770,7 +770,7 @@ class ImageGallery extends React.Component {
 
   canSlideRight() {
     const { infinite, isRTL } = this.props;
-    return infinite || isRTL ? this.canSlidePrevious() : this.canSlideNext();
+    return infinite || (isRTL ? this.canSlidePrevious() : this.canSlideNext());
   }
 
   canSlidePrevious() {

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -764,7 +764,7 @@ class ImageGallery extends React.Component {
 
   canSlideLeft() {
     const { infinite, isRTL } = this.props;
-    //so basically is the list is right to left (isRTL), the logic is inversed
+    //reverse the logic if the slider has isRTL enabled
     return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious());
   }
 

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -764,7 +764,7 @@ class ImageGallery extends React.Component {
 
   canSlideLeft() {
     const { infinite, isRTL } = this.props;
-    //reverse the logic if the slider has isRTL enabled
+    // reverse the logic if the slider has isRTL enabled
     return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious());
   }
 

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -772,7 +772,7 @@ class ImageGallery extends React.Component {
 
   canSlideRight() {
     const { infinite, isRTL } = this.props;
-    return infinite || isRTL ? this.canSlidePrevious() : this.canSlideNext(); 
+    return infinite || isRTL ? this.canSlidePrevious() : this.canSlideNext();
   }
 
   canSlidePrevious() {

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -763,14 +763,15 @@ class ImageGallery extends React.Component {
   }
 
   //SOLVED BY hunxjunedo : https://github.com/xiaolin/react-image-gallery/issues/767
+  //removed some minor errors, rmeove semi-colon
   canSlideLeft() {
-    const { infinite, isRTL } = this.props;
+    const { infinite, isRTL } = this.props
     //so basically is the list is right to left, the canSlideLeft depends on canSlideNext instead of canSlideRight
-    return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious());
+    return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious())
   }
 
   canSlideRight() {
-    const { infinite, isRTL } = this.props;
+    const { infinite, isRTL } = this.props
     return infinite || (isRTL ? this.canSlidePrevious() : this.canSlideNext() )
   }
 
@@ -781,7 +782,7 @@ class ImageGallery extends React.Component {
 
   canSlideNext() {
     const { currentIndex } = this.state;
-    const { items, isRTL } = this.props;
+    const { items } = this.props;
     return currentIndex < items.length - 1;
   }
 

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -762,11 +762,9 @@ class ImageGallery extends React.Component {
     return items.length >= 2;
   }
 
-  //SOLVED BY hunxjunedo : https://github.com/xiaolin/react-image-gallery/issues/767
-  //removed some minor errors, rmeove semi-colon
   canSlideLeft() {
     const { infinite, isRTL } = this.props;
-    //so basically is the list is right to left, the canSlideLeft depends on canSlideNext instead of canSlideRight
+    //so basically is the list is right to left (isRTL), the logic is inversed
     return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious());
   }
 

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -765,14 +765,14 @@ class ImageGallery extends React.Component {
   //SOLVED BY hunxjunedo : https://github.com/xiaolin/react-image-gallery/issues/767
   //removed some minor errors, rmeove semi-colon
   canSlideLeft() {
-    const { infinite, isRTL } = this.props
+    const { infinite, isRTL } = this.props;
     //so basically is the list is right to left, the canSlideLeft depends on canSlideNext instead of canSlideRight
-    return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious())
+    return infinite || (isRTL ? this.canSlideNext() : this.canSlidePrevious());
   }
 
   canSlideRight() {
-    const { infinite, isRTL } = this.props
-    return infinite || (isRTL ? this.canSlidePrevious() : this.canSlideNext() )
+    const { infinite, isRTL } = this.props;
+    return infinite || isRTL ? this.canSlidePrevious() : this.canSlideNext(); 
   }
 
   canSlidePrevious() {


### PR DESCRIPTION
fixed issue https://github.com/xiaolin/react-image-gallery/issues/767. Fixed to bug of left/right navigators only allowing to scroll to first and last image in RTL mode. Now both nav buttons allow slide in the correct direction.